### PR TITLE
refs qoretechnologies/qore#5061 Add McpClientDataProvider module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(QMOD
     qlib/JsonRpcConnection.qm
     qlib/McpServerHandler
     qlib/McpClient
+    qlib/McpClientDataProvider
 )
 
 # Check for C++11.
@@ -63,6 +64,7 @@ qore_external_user_module("qlib/JsonRpcConnection.qm" "")
 qore_external_user_module("qlib/JsonRpcHandler.qm" "")
 qore_external_user_module("qlib/McpServerHandler" "JsonRpcHandler")
 qore_external_user_module("qlib/McpClient" "")
+qore_external_user_module("qlib/McpClientDataProvider" "McpClient")
 
 qore_config_info()
 

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -25,6 +25,7 @@
       - <a href="../../JsonRpcHandler/html/index.html">JsonRpcHandler</a>
       - <a href="../../McpServerHandler/html/index.html">McpServerHandler</a>
       - <a href="../../McpClient/html/index.html">McpClient</a>
+      - <a href="../../McpClientDataProvider/html/index.html">McpClientDataProvider</a>
 
     This module is released under a choice of two licenses:
     - <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html">LGPL 2.1</a>
@@ -41,6 +42,7 @@
     - <a href="../../JsonRpcHandler/html/index.html">JsonRpcHandler</a> user module
     - <a href="../../McpServerHandler/html/index.html">McpServerHandler</a> user module
     - <a href="../../McpClient/html/index.html">McpClient</a> user module
+    - <a href="../../McpClientDataProvider/html/index.html">McpClientDataProvider</a> user module
 
     @note JSON functionality was included in the main %Qore shared library until version 0.8.1, at which time the code
     was removed to make this module.
@@ -172,6 +174,16 @@
     @section jsonreleasenotes Release Notes
 
     @subsection json_v1_10 json Module Version 1.10
+    - added the <a href="../../McpClientDataProvider/html/index.html">McpClientDataProvider</a> module providing a
+      DataProvider API for MCP servers:
+      - factory registration for automatic data provider discovery
+      - tools provider: list and call MCP tools
+      - resources provider: list and read MCP resources
+      - prompts provider: list and get MCP prompts
+      - completion provider: get autocompletion suggestions
+      - ping provider: verify server connectivity
+      - ConnectionProvider integration for connection management
+      - comprehensive type definitions for all MCP data structures
     - added the <a href="../../McpClient/html/index.html">McpClient</a> module for connecting to MCP servers as a
       client:
       - full MCP protocol support with automatic version negotiation (2024-11-05 through 2025-11-25)

--- a/qlib/McpClient/McpClient.qc
+++ b/qlib/McpClient/McpClient.qc
@@ -288,6 +288,11 @@ public class McpClient {
         close();
     }
 
+    #! Returns the server URL
+    string getUrl() {
+        return url;
+    }
+
     #! Initializes the MCP connection
     /**
         @param client_info information about this client

--- a/qlib/McpClientDataProvider/McpClientDataProvider.qc
+++ b/qlib/McpClientDataProvider/McpClientDataProvider.qc
@@ -1,0 +1,105 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpClientDataProvider class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! Root MCP client data provider
+/** Provides access to MCP server tools, resources, and prompts through the DataProvider API.
+
+    @par Example:
+    @code{.py}
+    McpClientDataProvider provider({"url": "mcp://localhost:8080"});
+    # List tools
+    auto tools = provider.getChildProvider("tools").getChildProvider("list").doRequest({});
+    # Call a tool
+    auto result = provider.getChildProvider("tools").getChildProvider("call").doRequest({
+        "name": "get_weather",
+        "arguments": {"city": "Prague"},
+    });
+    @endcode
+*/
+public class McpClientDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "type": "McpClientDataProvider",
+            "constructor_options": ConstructorOptions,
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+
+        #! Child providers
+        const ChildMap = {
+            "tools": Class::forName("McpClientDataProvider::McpToolsDataProvider"),
+            "resources": Class::forName("McpClientDataProvider::McpResourcesDataProvider"),
+            "prompts": Class::forName("McpClientDataProvider::McpPromptsDataProvider"),
+            "completion": Class::forName("McpClientDataProvider::McpCompletionDataProvider"),
+            "ping": Class::forName("McpClientDataProvider::McpPingDataProvider"),
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) : McpClientDataProviderBase(options) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "mcp";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return sprintf("MCP data provider for %s", mcp.getUrl());
+    }
+
+    #! Returns a list of child data provider names
+    private *list<string> getChildProviderNamesImpl() {
+        return keys ChildMap;
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        *Class cls = ChildMap{name};
+        if (!cls) {
+            return NOTHING;
+        }
+        @debug("Creating child provider %y", name);
+        return cls.newObject(mcp);
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/McpClientDataProvider/McpClientDataProvider.qm
+++ b/qlib/McpClientDataProvider/McpClientDataProvider.qm
@@ -1,0 +1,171 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpClientDataProvider module definition
+
+/*  McpClientDataProvider.qm Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%requires qore >= 2.0
+
+%requires(reexport) DataProvider
+%requires(reexport) ConnectionProvider
+%requires(reexport) McpClient
+
+%new-style
+%strict-args
+%require-types
+%enable-all-warnings
+
+module McpClientDataProvider {
+    version = "1.0";
+    desc = "user module providing a data provider API for MCP servers";
+    author = "David Nichols <david@qore.org>";
+    url = "https://qore.org";
+    license = "MIT";
+}
+
+/** @mainpage McpClientDataProvider Module
+
+    @tableofcontents
+
+    @section mcpclientdataproviderintro Introduction to the McpClientDataProvider Module
+
+    The %McpClientDataProvider module provides a @ref dataproviders "data provider" API for
+    MCP (Model Context Protocol) servers, enabling integration with AI tools, resources, and prompts.
+
+    The following classes are provided by this module:
+    - @ref McpClientDataProvider::McpClientDataProvider "McpClientDataProvider"
+    - @ref McpClientDataProvider::McpClientDataProviderFactory "McpClientDataProviderFactory"
+
+    @section mcpclientdataprovider_relnotes Release Notes
+
+    @subsection mcpclientdataprovider_v1_0 McpClientDataProvider v1.0
+    - initial release of the module
+*/
+
+#! contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+    #! Application name
+    public const AppName = "MCP";
+
+    #! MCP logo
+    public const McpLogo = "<svg fill=\"white\" fill-rule=\"evenodd\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M15.688 2.343a2.588 2.588 0 00-3.61 0l-9.626 9.44a.863.863 0 01-1.203 0 .823.823 0 010-1.18l9.626-9.44a4.313 4.313 0 016.016 0 4.116 4.116 0 011.204 3.54 4.3 4.3 0 013.609 1.18l.05.05a4.115 4.115 0 010 5.9l-8.706 8.537a.274.274 0 000 .393l1.788 1.754a.823.823 0 010 1.18.863.863 0 01-1.203 0l-1.788-1.753a1.92 1.92 0 010-2.754l8.706-8.538a2.47 2.47 0 000-3.54l-.05-.049a2.588 2.588 0 00-3.607-.003l-7.172 7.034-.002.002-.098.097a.863.863 0 01-1.204 0 .823.823 0 010-1.18l7.273-7.133a2.47 2.47 0 00-.003-3.537z\"></path><path d=\"M14.485 4.703a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a4.115 4.115 0 000 5.9 4.314 4.314 0 006.016 0l7.12-6.982a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a2.588 2.588 0 01-3.61 0 2.47 2.47 0 010-3.54l7.12-6.982z\"></path></svg>";
+}
+
+# private namespace for the module
+namespace Priv {
+    sub priv_init() {
+        # Register the data provider factory
+        DataProvider::registerFactory(new McpClientDataProviderFactory());
+
+        # Register the app
+        DataProviderActionCatalog::registerApp(<DataProviderAppInfo>{
+            "name": McpClientDataProvider::AppName,
+            "display_name": "MCP Server",
+            "short_desc": "Model Context Protocol server",
+            "desc": "Connect to MCP servers for AI tool, resource, and prompt integration",
+            "scheme": "mcp",
+            "logo": McpClientDataProvider::McpLogo,
+            "logo_file_name": "mcp-logo.svg",
+            "logo_mime_type": MimeTypeSvg,
+        });
+
+        # Register actions
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": McpClientDataProvider::AppName,
+            "path": "/tools/call",
+            "action": "call-tool",
+            "display_name": "Call Tool",
+            "short_desc": "Execute an MCP tool",
+            "desc": "Execute an MCP tool with the provided arguments and return the result",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": McpClientDataProvider::AppName,
+            "path": "/tools/list",
+            "action": "list-tools",
+            "display_name": "List Tools",
+            "short_desc": "List available MCP tools",
+            "desc": "List all tools available on the MCP server",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": McpClientDataProvider::AppName,
+            "path": "/resources/read",
+            "action": "read-resource",
+            "display_name": "Read Resource",
+            "short_desc": "Read an MCP resource",
+            "desc": "Read content from an MCP resource by URI",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": McpClientDataProvider::AppName,
+            "path": "/resources/list",
+            "action": "list-resources",
+            "display_name": "List Resources",
+            "short_desc": "List available MCP resources",
+            "desc": "List all resources available on the MCP server",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": McpClientDataProvider::AppName,
+            "path": "/prompts/get",
+            "action": "get-prompt",
+            "display_name": "Get Prompt",
+            "short_desc": "Get an MCP prompt",
+            "desc": "Get a prompt template from the MCP server with arguments",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": McpClientDataProvider::AppName,
+            "path": "/prompts/list",
+            "action": "list-prompts",
+            "display_name": "List Prompts",
+            "short_desc": "List available MCP prompts",
+            "desc": "List all prompts available on the MCP server",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": McpClientDataProvider::AppName,
+            "path": "/completion",
+            "action": "complete",
+            "display_name": "Get Completion",
+            "short_desc": "Get autocompletion suggestions",
+            "desc": "Get autocompletion suggestions for prompts or resources",
+            "action_code": DPAT_API,
+        });
+
+        DataProviderActionCatalog::registerAction(<DataProviderActionInfo>{
+            "app": McpClientDataProvider::AppName,
+            "path": "/ping",
+            "action": "ping",
+            "display_name": "Ping Server",
+            "short_desc": "Check server connectivity",
+            "desc": "Ping the MCP server to verify connectivity",
+            "action_code": DPAT_API,
+        });
+    }
+}

--- a/qlib/McpClientDataProvider/McpClientDataProviderBase.qc
+++ b/qlib/McpClientDataProvider/McpClientDataProviderBase.qc
@@ -1,0 +1,109 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpClientDataProviderBase class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! Base class for MCP client data providers
+public class McpClientDataProviderBase inherits DataProvider::AbstractDataProvider {
+    public {
+        #! Constructor options
+        const ConstructorOptions = {
+            "mcp": <DataProviderOptionInfo>{
+                "display_name": "MCP Client",
+                "short_desc": "The MCP client object",
+                "type": AbstractDataProviderType::get(new Type("McpClient")),
+                "desc": "The MCP client object to use for API calls",
+            },
+            "mcpconnection": <DataProviderOptionInfo>{
+                "display_name": "MCP Connection",
+                "short_desc": "The name of the MCP connection",
+                "type": AbstractDataProviderType::get(StringType),
+                "desc": "The name of the MCP connection to use",
+            },
+            "url": <DataProviderOptionInfo>{
+                "display_name": "URL",
+                "short_desc": "The URL to the MCP server",
+                "type": AbstractDataProviderType::get(StringType),
+                "desc": "The URL to the MCP server (mcp:// or mcps://)",
+            },
+        };
+    }
+
+    private {
+        #! The MCP client
+        McpClient mcp;
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) {
+        @assert(mcp);
+        self.mcp = mcp;
+    }
+
+    #! Creates the object from constructor options
+    constructor(*hash<auto> options) {
+        *McpClient mcp = McpClientDataProviderBase::getMcpClient(options);
+        if (!mcp) {
+            mcp = McpClientDataProviderBase::getMcpClientFromConnection(options);
+        }
+        @assert(mcp);
+        self.mcp = mcp;
+    }
+
+    #! Returns the MCP client
+    McpClient getMcpClient() {
+        return mcp;
+    }
+
+    #! Returns the MCP client from options
+    static *McpClient getMcpClient(*hash<auto> options) {
+        if (options.mcp) {
+            return options.mcp;
+        }
+        if (options.url) {
+            @debug("Creating MCP client from URL: %y", options.url);
+            return new McpClient(options.url, {
+                "name": options.client_name ?? "QoreDataProvider",
+                "version": options.client_version ?? "1.0",
+            });
+        }
+        return NOTHING;
+    }
+
+    #! Returns the MCP client from a connection
+    static *McpClient getMcpClientFromConnection(*hash<auto> options) {
+        if (options.mcpconnection) {
+            @debug("Getting MCP client from connection: %y", options.mcpconnection);
+            AbstractConnection conn = get_connection(options.mcpconnection);
+            return conn.get();
+        }
+        return NOTHING;
+    }
+}
+}

--- a/qlib/McpClientDataProvider/McpClientDataProviderFactory.qc
+++ b/qlib/McpClientDataProvider/McpClientDataProviderFactory.qc
@@ -1,0 +1,82 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpClientDataProviderFactory class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! Factory class for MCP client data providers
+public class McpClientDataProviderFactory inherits DataProvider::AbstractDataProviderFactory {
+    public {
+        #! Factory info
+        const FactoryInfo = <DataProviderFactoryInfo>{
+            "name": "McpClientDataProvider",
+            "desc": "Data provider factory for MCP (Model Context Protocol) server connections",
+            "children_can_support_apis": True,
+        };
+    }
+
+    #! Returns the factory info
+    hash<DataProviderFactoryInfo> getInfoImpl() {
+        return FactoryInfo;
+    }
+
+    #! Returns the class for the data provider
+    Class getClassImpl() {
+        return Class::forName("McpClientDataProvider::McpClientDataProvider");
+    }
+
+    #! Returns the data provider from the given options
+    /** @param options the options for the data provider; one of:
+        - \c mcp: an McpClient object
+        - \c mcpconnection: the name of an MCP connection
+        - \c url: the URL to the MCP server
+        @param logger an optional logger
+
+        @return the data provider created from the given options
+    */
+    private DataProvider::AbstractDataProvider createImpl(hash<auto> options, *LoggerInterface logger) {
+        @debug("Creating MCP client data provider with options: %y", options);
+        return new McpClientDataProvider(options);
+    }
+
+    #! Returns static provider information as data; no connection is required
+    *hash<auto> getInfoAsDataImpl(hash<auto> constructor_options, *bool with_type_info) {
+        return McpClientDataProvider::ProviderInfo;
+    }
+
+    #! Returns the description of the factory
+    string getDescImpl() {
+        return FactoryInfo.desc;
+    }
+
+    #! Returns provider info
+    private hash<DataProvider::DataProviderInfo> getProviderInfoImpl() {
+        return McpClientDataProvider::ProviderInfo;
+    }
+}
+}

--- a/qlib/McpClientDataProvider/McpContentItemDataType.qc
+++ b/qlib/McpClientDataProvider/McpContentItemDataType.qc
@@ -1,0 +1,86 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpContentItemDataType class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP content item data type
+public class McpContentItemDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "type": {
+                "type": StringType,
+                "display_name": "Type",
+                "short_desc": "Content type",
+                "desc": "Content type: text, image, or resource",
+                "example_value": "text",
+            },
+            "text": {
+                "type": StringOrNothingType,
+                "display_name": "Text",
+                "short_desc": "Text content",
+                "desc": "Text content (for type=text)",
+            },
+            "mimeType": {
+                "type": StringOrNothingType,
+                "display_name": "MIME Type",
+                "short_desc": "Content MIME type",
+                "desc": "MIME type of the content",
+                "example_value": "text/plain",
+            },
+            "data": {
+                "type": StringOrNothingType,
+                "display_name": "Data",
+                "short_desc": "Binary data",
+                "desc": "Base64-encoded binary data (for type=image)",
+            },
+            "uri": {
+                "type": StringOrNothingType,
+                "display_name": "URI",
+                "short_desc": "Resource URI",
+                "desc": "Resource URI (for type=resource)",
+            },
+            "isError": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Is Error",
+                "short_desc": "Error indicator",
+                "desc": "Whether this content item represents an error",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP content item data type constant
+public const McpContentItemDataType = new McpContentItemDataType();
+}

--- a/qlib/McpClientDataProvider/McpPromptInfoDataType.qc
+++ b/qlib/McpClientDataProvider/McpPromptInfoDataType.qc
@@ -1,0 +1,169 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpPromptInfoDataType class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP prompt argument data type
+public class McpPromptArgumentDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "name": {
+                "type": StringType,
+                "display_name": "Name",
+                "short_desc": "Argument name",
+                "desc": "The name of the prompt argument",
+            },
+            "description": {
+                "type": StringOrNothingType,
+                "display_name": "Description",
+                "short_desc": "Argument description",
+                "desc": "Description of the argument",
+            },
+            "required": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Required",
+                "short_desc": "Is required",
+                "desc": "Whether the argument is required",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP prompt argument data type constant
+public const McpPromptArgumentDataType = new McpPromptArgumentDataType();
+
+#! MCP prompt information data type
+public class McpPromptInfoDataType inherits HashDataType {
+    private {
+        #! Field descriptions for simple types
+        const Fields = {
+            "name": {
+                "type": StringType,
+                "display_name": "Name",
+                "short_desc": "Prompt name",
+                "desc": "The unique name of the prompt",
+                "example_value": "code_review",
+            },
+            "description": {
+                "type": StringOrNothingType,
+                "display_name": "Description",
+                "short_desc": "Prompt description",
+                "desc": "Human-readable description of the prompt",
+            },
+        };
+
+        #! Arguments field description
+        const ArgumentsField = {
+            "display_name": "Arguments",
+            "short_desc": "Prompt arguments",
+            "desc": "List of arguments the prompt accepts",
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        addField(new QoreDataField("arguments", ArgumentsField.desc,
+            new ListDataType("arguments", McpPromptArgumentDataType, True)));
+    }
+}
+
+#! MCP prompt info data type constant
+public const McpPromptInfoDataType = new McpPromptInfoDataType();
+
+#! MCP prompt message data type
+public class McpPromptMessageDataType inherits HashDataType {
+    private {
+        #! Field descriptions for simple types
+        const Fields = {
+            "role": {
+                "type": StringType,
+                "display_name": "Role",
+                "short_desc": "Message role",
+                "desc": "The role of the message sender: user or assistant",
+                "example_value": "user",
+            },
+        };
+
+        #! Content field description
+        const ContentField = {
+            "display_name": "Content",
+            "short_desc": "Message content",
+            "desc": "The content of the message",
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        addField(new QoreDataField("content", ContentField.desc, McpContentItemDataType));
+    }
+}
+
+#! MCP prompt message data type constant
+public const McpPromptMessageDataType = new McpPromptMessageDataType();
+
+#! MCP prompt result data type
+public class McpPromptResultDataType inherits HashDataType {
+    private {
+        #! Field descriptions for simple types
+        const Fields = {
+            "description": {
+                "type": StringOrNothingType,
+                "display_name": "Description",
+                "short_desc": "Prompt description",
+                "desc": "Optional description of the prompt result",
+            },
+        };
+
+        #! Messages field description
+        const MessagesField = {
+            "display_name": "Messages",
+            "short_desc": "Prompt messages",
+            "desc": "List of prompt messages",
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        addField(new QoreDataField("messages", MessagesField.desc,
+            new ListDataType("messages", McpPromptMessageDataType, True)));
+    }
+}
+
+#! MCP prompt result data type constant
+public const McpPromptResultDataType = new McpPromptResultDataType();
+}

--- a/qlib/McpClientDataProvider/McpPromptsDataProvider.qc
+++ b/qlib/McpClientDataProvider/McpPromptsDataProvider.qc
@@ -1,0 +1,192 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpPromptsDataProvider class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP prompts container data provider
+/** Provides access to MCP server prompts.
+
+    Children:
+    - \c list: list available prompts
+    - \c get: get a prompt by name
+*/
+public class McpPromptsDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "prompts",
+            "desc": "MCP prompts data provider; provides access to server prompts",
+            "type": "McpPromptsDataProvider",
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "prompts";
+    }
+
+    #! Returns a list of child data provider names
+    private *list<string> getChildProviderNamesImpl() {
+        return ("list", "get");
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        switch (name) {
+            case "list":
+                return new McpPromptsListDataProvider(mcp);
+            case "get":
+                return new McpPromptGetDataProvider(mcp);
+        }
+        return NOTHING;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! MCP prompts list data provider
+/** Lists all available prompts on the MCP server.
+*/
+public class McpPromptsListDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list",
+            "desc": "Lists all available prompts on the MCP server",
+            "type": "McpPromptsListDataProvider",
+            "supports_request": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "list";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Lists all available prompts on the MCP server";
+    }
+
+    #! Returns the request type
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return NOTHING;
+    }
+
+    #! Returns the response type
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return McpPromptsListResultDataType;
+    }
+
+    #! Performs the request
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        @debug("Listing prompts");
+        list<auto> prompts = mcp.listPrompts();
+        @debug {
+            printf("Found %d prompts\n", prompts.size());
+        }
+        return {
+            "prompts": prompts,
+        };
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! MCP prompt get data provider
+/** Gets a prompt from the MCP server by name with optional arguments.
+*/
+public class McpPromptGetDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "get",
+            "desc": "Gets a prompt from the MCP server by name with optional arguments",
+            "type": "McpPromptGetDataProvider",
+            "supports_request": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "get";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Gets a prompt from the MCP server by name with optional arguments";
+    }
+
+    #! Returns the request type
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return McpPromptGetRequestDataType;
+    }
+
+    #! Returns the response type
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return McpPromptResultDataType;
+    }
+
+    #! Performs the request
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        @assert(req.name);
+        @debug("Getting prompt %y with arguments: %y", req.name, req.arguments);
+        hash<auto> result = mcp.getPrompt(req.name, req.arguments);
+        @debug {
+            printf("Prompt %y returned %d messages\n", req.name, result.messages.size());
+        }
+        return result;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/McpClientDataProvider/McpRequestDataTypes.qc
+++ b/qlib/McpClientDataProvider/McpRequestDataTypes.qc
@@ -1,0 +1,265 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore MCP request data types
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP tool call request data type
+public class McpToolCallRequestDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "name": {
+                "type": StringType,
+                "display_name": "Tool Name",
+                "short_desc": "Name of the tool to call",
+                "desc": "The name of the MCP tool to execute",
+                "example_value": "get_weather",
+            },
+            "arguments": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Arguments",
+                "short_desc": "Tool arguments",
+                "desc": "Arguments to pass to the tool (structure depends on the tool's inputSchema)",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP tool call request data type constant
+public const McpToolCallRequestDataType = new McpToolCallRequestDataType();
+
+#! MCP resource read request data type
+public class McpResourceReadRequestDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "uri": {
+                "type": StringType,
+                "display_name": "URI",
+                "short_desc": "Resource URI",
+                "desc": "The URI of the resource to read",
+                "example_value": "file:///config.json",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP resource read request data type constant
+public const McpResourceReadRequestDataType = new McpResourceReadRequestDataType();
+
+#! MCP prompt get request data type
+public class McpPromptGetRequestDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "name": {
+                "type": StringType,
+                "display_name": "Prompt Name",
+                "short_desc": "Name of the prompt",
+                "desc": "The name of the prompt to retrieve",
+                "example_value": "code_review",
+            },
+            "arguments": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Arguments",
+                "short_desc": "Prompt arguments",
+                "desc": "Arguments to pass to the prompt template",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP prompt get request data type constant
+public const McpPromptGetRequestDataType = new McpPromptGetRequestDataType();
+
+#! MCP completion request data type
+public class McpCompletionRequestDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "ref_type": {
+                "type": StringType,
+                "display_name": "Reference Type",
+                "short_desc": "Type of completion reference",
+                "desc": "The type of completion reference: 'ref/prompt' or 'ref/resource'",
+                "example_value": "ref/prompt",
+            },
+            "ref_name": {
+                "type": StringType,
+                "display_name": "Reference Name",
+                "short_desc": "Name or URI of the reference",
+                "desc": "The name (for prompts) or URI (for resources) to complete",
+            },
+            "argument_name": {
+                "type": StringType,
+                "display_name": "Argument Name",
+                "short_desc": "Argument to complete",
+                "desc": "The name of the argument to get completions for",
+            },
+            "argument_value": {
+                "type": StringType,
+                "display_name": "Argument Value",
+                "short_desc": "Partial value",
+                "desc": "The partial value to complete",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP completion request data type constant
+public const McpCompletionRequestDataType = new McpCompletionRequestDataType();
+
+#! MCP completion result data type
+public class McpCompletionResultDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "values": {
+                "type": AutoListType,
+                "display_name": "Values",
+                "short_desc": "Completion values",
+                "desc": "List of completion suggestions",
+            },
+            "total": {
+                "type": SoftIntOrNothingType,
+                "display_name": "Total",
+                "short_desc": "Total count",
+                "desc": "Total number of available completions (if known)",
+            },
+            "hasMore": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Has More",
+                "short_desc": "More available",
+                "desc": "Whether there are more completions available",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP completion result data type constant
+public const McpCompletionResultDataType = new McpCompletionResultDataType();
+
+#! MCP ping result data type (empty response)
+public class McpPingResultDataType inherits HashDataType {
+    #! Creates the object
+    constructor() {
+    }
+}
+
+#! MCP ping result data type constant
+public const McpPingResultDataType = new McpPingResultDataType();
+
+#! MCP tools list result data type
+public class McpToolsListResultDataType inherits HashDataType {
+    private {
+        #! Tools field description
+        const ToolsField = {
+            "display_name": "Tools",
+            "short_desc": "Available tools",
+            "desc": "List of tools available on the server",
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addField(new QoreDataField("tools", ToolsField.desc,
+            new ListDataType("tools", McpToolInfoDataType, True)));
+    }
+}
+
+#! MCP tools list result data type constant
+public const McpToolsListResultDataType = new McpToolsListResultDataType();
+
+#! MCP resources list result data type
+public class McpResourcesListResultDataType inherits HashDataType {
+    private {
+        #! Resources field description
+        const ResourcesField = {
+            "display_name": "Resources",
+            "short_desc": "Available resources",
+            "desc": "List of resources available on the server",
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addField(new QoreDataField("resources", ResourcesField.desc,
+            new ListDataType("resources", McpResourceInfoDataType, True)));
+    }
+}
+
+#! MCP resources list result data type constant
+public const McpResourcesListResultDataType = new McpResourcesListResultDataType();
+
+#! MCP prompts list result data type
+public class McpPromptsListResultDataType inherits HashDataType {
+    private {
+        #! Prompts field description
+        const PromptsField = {
+            "display_name": "Prompts",
+            "short_desc": "Available prompts",
+            "desc": "List of prompts available on the server",
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addField(new QoreDataField("prompts", PromptsField.desc,
+            new ListDataType("prompts", McpPromptInfoDataType, True)));
+    }
+}
+
+#! MCP prompts list result data type constant
+public const McpPromptsListResultDataType = new McpPromptsListResultDataType();
+}

--- a/qlib/McpClientDataProvider/McpResourceInfoDataType.qc
+++ b/qlib/McpClientDataProvider/McpResourceInfoDataType.qc
@@ -1,0 +1,96 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpResourceInfoDataType class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP resource information data type
+public class McpResourceInfoDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "uri": {
+                "type": StringType,
+                "display_name": "URI",
+                "short_desc": "Resource URI",
+                "desc": "The unique URI identifying the resource",
+                "example_value": "file:///config.json",
+            },
+            "name": {
+                "type": StringType,
+                "display_name": "Name",
+                "short_desc": "Resource name",
+                "desc": "Human-readable name for the resource",
+                "example_value": "Configuration File",
+            },
+            "description": {
+                "type": StringOrNothingType,
+                "display_name": "Description",
+                "short_desc": "Resource description",
+                "desc": "Human-readable description of the resource",
+            },
+            "mimeType": {
+                "type": StringOrNothingType,
+                "display_name": "MIME Type",
+                "short_desc": "Content MIME type",
+                "desc": "MIME type of the resource content",
+                "example_value": "application/json",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP resource info data type constant
+public const McpResourceInfoDataType = new McpResourceInfoDataType();
+
+#! MCP resource content data type
+public class McpResourceContentDataType inherits HashDataType {
+    private {
+        #! Contents field description
+        const ContentsField = {
+            "display_name": "Contents",
+            "short_desc": "Resource contents",
+            "desc": "List of resource content items",
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addField(new QoreDataField("contents", ContentsField.desc,
+            new ListDataType("contents", McpContentItemDataType, True)));
+    }
+}
+
+#! MCP resource content data type constant
+public const McpResourceContentDataType = new McpResourceContentDataType();
+}

--- a/qlib/McpClientDataProvider/McpResourcesDataProvider.qc
+++ b/qlib/McpClientDataProvider/McpResourcesDataProvider.qc
@@ -1,0 +1,192 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpResourcesDataProvider class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP resources container data provider
+/** Provides access to MCP server resources.
+
+    Children:
+    - \c list: list available resources
+    - \c read: read a resource by URI
+*/
+public class McpResourcesDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "resources",
+            "desc": "MCP resources data provider; provides access to server resources",
+            "type": "McpResourcesDataProvider",
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "resources";
+    }
+
+    #! Returns a list of child data provider names
+    private *list<string> getChildProviderNamesImpl() {
+        return ("list", "read");
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        switch (name) {
+            case "list":
+                return new McpResourcesListDataProvider(mcp);
+            case "read":
+                return new McpResourceReadDataProvider(mcp);
+        }
+        return NOTHING;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! MCP resources list data provider
+/** Lists all available resources on the MCP server.
+*/
+public class McpResourcesListDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list",
+            "desc": "Lists all available resources on the MCP server",
+            "type": "McpResourcesListDataProvider",
+            "supports_request": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "list";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Lists all available resources on the MCP server";
+    }
+
+    #! Returns the request type
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return NOTHING;
+    }
+
+    #! Returns the response type
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return McpResourcesListResultDataType;
+    }
+
+    #! Performs the request
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        @debug("Listing resources");
+        list<auto> resources = mcp.listResources();
+        @debug {
+            printf("Found %d resources\n", resources.size());
+        }
+        return {
+            "resources": resources,
+        };
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! MCP resource read data provider
+/** Reads a resource from the MCP server by URI.
+*/
+public class McpResourceReadDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "read",
+            "desc": "Reads a resource from the MCP server by URI",
+            "type": "McpResourceReadDataProvider",
+            "supports_request": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "read";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Reads a resource from the MCP server by URI";
+    }
+
+    #! Returns the request type
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return McpResourceReadRequestDataType;
+    }
+
+    #! Returns the response type
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return McpResourceContentDataType;
+    }
+
+    #! Performs the request
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        @assert(req.uri);
+        @debug("Reading resource: %y", req.uri);
+        hash<auto> result = mcp.readResource(req.uri);
+        @debug {
+            printf("Resource %y returned %d content items\n", req.uri, result.contents.size());
+        }
+        return result;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/McpClientDataProvider/McpToolInfoDataType.qc
+++ b/qlib/McpClientDataProvider/McpToolInfoDataType.qc
@@ -1,0 +1,67 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpToolInfoDataType class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP tool information data type
+public class McpToolInfoDataType inherits HashDataType {
+    private {
+        #! Field descriptions
+        const Fields = {
+            "name": {
+                "type": StringType,
+                "display_name": "Name",
+                "short_desc": "Tool name",
+                "desc": "The unique name of the tool",
+                "example_value": "get_weather",
+            },
+            "description": {
+                "type": StringOrNothingType,
+                "display_name": "Description",
+                "short_desc": "Tool description",
+                "desc": "Human-readable description of what the tool does",
+            },
+            "inputSchema": {
+                "type": AutoHashOrNothingType,
+                "display_name": "Input Schema",
+                "short_desc": "JSON Schema for input",
+                "desc": "JSON Schema defining the tool's input parameters",
+            },
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+    }
+}
+
+#! MCP tool info data type constant
+public const McpToolInfoDataType = new McpToolInfoDataType();
+}

--- a/qlib/McpClientDataProvider/McpToolResultDataType.qc
+++ b/qlib/McpClientDataProvider/McpToolResultDataType.qc
@@ -1,0 +1,64 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpToolResultDataType class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP tool result data type
+public class McpToolResultDataType inherits HashDataType {
+    private {
+        #! Field descriptions for simple types
+        const Fields = {
+            "isError": {
+                "type": SoftBoolOrNothingType,
+                "display_name": "Is Error",
+                "short_desc": "Error indicator",
+                "desc": "Whether the tool call resulted in an error",
+                "default_value": False,
+            },
+        };
+
+        #! Content field description
+        const ContentField = {
+            "display_name": "Content",
+            "short_desc": "Result content",
+            "desc": "List of content items returned by the tool",
+        };
+    }
+
+    #! Creates the object
+    constructor() {
+        addQoreFields(Fields);
+        addField(new QoreDataField("content", ContentField.desc, new ListDataType("content",
+            McpContentItemDataType, True)));
+    }
+}
+
+#! MCP tool result data type constant
+public const McpToolResultDataType = new McpToolResultDataType();
+}

--- a/qlib/McpClientDataProvider/McpToolsDataProvider.qc
+++ b/qlib/McpClientDataProvider/McpToolsDataProvider.qc
@@ -1,0 +1,192 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore McpToolsDataProvider class definition
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP tools container data provider
+/** Provides access to MCP server tools.
+
+    Children:
+    - \c list: list available tools
+    - \c call: call a tool
+*/
+public class McpToolsDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "tools",
+            "desc": "MCP tools data provider; provides access to server tools",
+            "type": "McpToolsDataProvider",
+            "supports_children": True,
+            "children_can_support_apis": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "tools";
+    }
+
+    #! Returns a list of child data provider names
+    private *list<string> getChildProviderNamesImpl() {
+        return ("list", "call");
+    }
+
+    #! Returns the given child provider or @ref nothing if the given child is unknown
+    private *DataProvider::AbstractDataProvider getChildProviderImpl(string name) {
+        switch (name) {
+            case "list":
+                return new McpToolsListDataProvider(mcp);
+            case "call":
+                return new McpToolCallDataProvider(mcp);
+        }
+        return NOTHING;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! MCP tools list data provider
+/** Lists all available tools on the MCP server.
+*/
+public class McpToolsListDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "list",
+            "desc": "Lists all available tools on the MCP server",
+            "type": "McpToolsListDataProvider",
+            "supports_request": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "list";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Lists all available tools on the MCP server";
+    }
+
+    #! Returns the request type
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return NOTHING;
+    }
+
+    #! Returns the response type
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return McpToolsListResultDataType;
+    }
+
+    #! Performs the request
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        @debug("Listing tools");
+        list<auto> tools = mcp.listTools();
+        @debug {
+            printf("Found %d tools\n", tools.size());
+        }
+        return {
+            "tools": tools,
+        };
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! MCP tool call data provider
+/** Calls an MCP tool by name with arguments.
+*/
+public class McpToolCallDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "call",
+            "desc": "Calls an MCP tool by name with the provided arguments",
+            "type": "McpToolCallDataProvider",
+            "supports_request": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "call";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Calls an MCP tool by name with the provided arguments";
+    }
+
+    #! Returns the request type
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return McpToolCallRequestDataType;
+    }
+
+    #! Returns the response type
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return McpToolResultDataType;
+    }
+
+    #! Performs the request
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        @assert(req.name);
+        @debug("Calling tool %y with arguments: %y", req.name, req.arguments);
+        hash<auto> result = mcp.callTool(req.name, req.arguments);
+        @debug {
+            printf("Tool %y returned: %y\n", req.name, result);
+        }
+        return result;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qlib/McpClientDataProvider/McpUtilityDataProviders.qc
+++ b/qlib/McpClientDataProvider/McpUtilityDataProviders.qc
@@ -1,0 +1,160 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! Qore MCP utility data providers
+
+/*  Copyright 2025 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%require-types
+%enable-all-warnings
+%new-style
+%strict-args
+
+#! Contains all public definitions in the McpClientDataProvider module
+public namespace McpClientDataProvider {
+#! MCP completion data provider
+/** Provides autocompletion suggestions for prompts or resources.
+*/
+public class McpCompletionDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "completion",
+            "desc": "Provides autocompletion suggestions for prompts or resources",
+            "type": "McpCompletionDataProvider",
+            "supports_request": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "completion";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Provides autocompletion suggestions for prompts or resources";
+    }
+
+    #! Returns the request type
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return McpCompletionRequestDataType;
+    }
+
+    #! Returns the response type
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return McpCompletionResultDataType;
+    }
+
+    #! Performs the request
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        @assert(req.ref_type);
+        @assert(req.ref_name);
+        @assert(req.argument_name);
+        @assert(exists req.argument_value);
+
+        @debug("Getting completion for %y/%y: %y=%y", req.ref_type, req.ref_name,
+            req.argument_name, req.argument_value);
+
+        hash<auto> ref = {
+            "type": req.ref_type,
+        };
+        if (req.ref_type == "ref/prompt") {
+            ref.name = req.ref_name;
+        } else {
+            ref.uri = req.ref_name;
+        }
+
+        hash<auto> argument = {
+            "name": req.argument_name,
+            "value": req.argument_value,
+        };
+
+        hash<auto> result = mcp.complete(ref, argument);
+        @debug {
+            printf("Completion returned %d values\n", result.completion.values.size());
+        }
+        return result.completion;
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+
+#! MCP ping data provider
+/** Pings the MCP server to verify connectivity.
+*/
+public class McpPingDataProvider inherits McpClientDataProviderBase {
+    public {
+        #! Provider info
+        const ProviderInfo = <DataProviderInfo>{
+            "name": "ping",
+            "desc": "Pings the MCP server to verify connectivity",
+            "type": "McpPingDataProvider",
+            "supports_request": True,
+        };
+    }
+
+    #! Creates the object with the given MCP client
+    constructor(McpClient mcp) : McpClientDataProviderBase(mcp) {
+    }
+
+    #! Returns the data provider name
+    string getName() {
+        return "ping";
+    }
+
+    #! Returns the data provider description
+    *string getDesc() {
+        return "Pings the MCP server to verify connectivity";
+    }
+
+    #! Returns the request type
+    private *DataProvider::AbstractDataProviderType getRequestTypeImpl() {
+        return NOTHING;
+    }
+
+    #! Returns the response type
+    private *DataProvider::AbstractDataProviderType getResponseTypeImpl() {
+        return McpPingResultDataType;
+    }
+
+    #! Performs the request
+    private auto doRequestImpl(auto req, *hash<auto> request_options) {
+        @debug("Pinging MCP server");
+        mcp.ping();
+        @debug {
+            printf("Ping successful\n");
+        }
+        return {};
+    }
+
+    #! Returns data provider static info
+    private hash<DataProvider::DataProviderInfo> getStaticInfoImpl() {
+        return ProviderInfo;
+    }
+}
+}

--- a/qore-json-module.spec
+++ b/qore-json-module.spec
@@ -98,6 +98,7 @@ qore -l ./json-api-%{module_api}.qmod test/JsonRpcClient.qtest -v
 qore -l ./json-api-%{module_api}.qmod test/JsonRpcHandler.qtest -v
 qore -l ./json-api-%{module_api}.qmod test/McpServerHandler.qtest -v
 qore -l ./json-api-%{module_api}.qmod test/McpClient.qtest -v
+qore -l ./json-api-%{module_api}.qmod test/McpClientDataProvider.qtest -v
 qore -l ./json-api-%{module_api}.qmod test/json.qtest -v
 
 %package doc
@@ -110,11 +111,12 @@ json module.
 
 %files doc
 %defattr(-,root,root,-)
-%doc docs/json docs/JsonRpcConnection docs/JsonRpcHandler docs/McpServerHandler docs/McpClient test examples
+%doc docs/json docs/JsonRpcConnection docs/JsonRpcHandler docs/McpServerHandler docs/McpClient docs/McpClientDataProvider test examples
 
 %changelog
 * Sun Dec 29 2025 David Nichols <david@qore.org> - 1.10
 - updated to version 1.10
+- added McpClientDataProvider module for DataProvider API access to MCP servers
 - added McpClient module for connecting to MCP servers as a client
 - added MCP 2025-11-25 protocol version support
 - added completion/complete, logging/setLevel methods

--- a/test/McpClientDataProvider.qtest
+++ b/test/McpClientDataProvider.qtest
@@ -1,0 +1,449 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%strict-args
+%require-types
+%enable-all-warnings
+
+%requires QUnit
+%requires HttpServer
+%requires Logger
+%requires json
+%requires Mime
+%requires DataProvider
+%requires ../qlib/McpServerHandler
+%requires ../qlib/McpClient
+%requires ../qlib/McpClientDataProvider
+
+%exec-class McpClientDataProviderTest
+
+class TestMcpServerHandler inherits McpServerHandler {
+    constructor(LoggerInterface logger) : McpServerHandler(logger, new PermissiveAuthenticator()) {
+        registerTool("echo", "Echoes the input", NOTHING, \echoCallback());
+        registerTool("add", "Adds two numbers", NOTHING, \addCallback());
+        registerTool("error-tool", "Throws an error", NOTHING, \errorCallback());
+        registerTool("no-args-tool", "A tool with no arguments", NOTHING, \noArgsCallback());
+        registerResource("file:///test.txt", "Test File", "A test file", "text/plain", \readTestFile());
+        registerResource("file:///empty.txt", "Empty File", "An empty file", "text/plain", \readEmptyFile());
+        registerPrompt("greeting", "A greeting prompt", (
+            {"name": "name", "description": "The name to greet", "required": True},
+        ), \greetingHandler());
+        registerPrompt("simple", "A simple prompt without arguments");
+    }
+
+    hash<auto> echoCallback(*hash<auto> args) {
+        return args ?? {};
+    }
+
+    hash<auto> addCallback(*hash<auto> args) {
+        return {"result": (args.a ?? 0) + (args.b ?? 0)};
+    }
+
+    nothing errorCallback(*hash<auto> args) {
+        throw "TEST-ERROR", "This is a test error";
+    }
+
+    hash<auto> noArgsCallback(*hash<auto> args) {
+        return {"status": "ok"};
+    }
+
+    string readTestFile(hash<auto> cx, string uri) {
+        return "Hello, World!";
+    }
+
+    string readEmptyFile(hash<auto> cx, string uri) {
+        return "";
+    }
+
+    list<hash<auto>> greetingHandler(hash<auto> cx, *hash<auto> arguments) {
+        return ({
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "Hello, " + (arguments.name ?? "World"),
+            },
+        },);
+    }
+}
+
+class McpClientDataProviderTest inherits QUnit::Test {
+    private {
+        HttpServer server;
+        int port;
+        McpClientDataProvider provider;
+        McpClient client;
+        TestMcpServerHandler mcpServer;
+    }
+
+    constructor() : Test("McpClientDataProvider", "1.0") {
+        addTestCase("data provider factory test", \testFactory());
+        addTestCase("data provider children test", \testChildren());
+        addTestCase("tools provider test", \testToolsProvider());
+        addTestCase("resources provider test", \testResourcesProvider());
+        addTestCase("prompts provider test", \testPromptsProvider());
+        addTestCase("ping provider test", \testPingProvider());
+        addTestCase("completion provider test", \testCompletionProvider());
+        addTestCase("type definitions test", \testTypeDefinitions());
+        addTestCase("negative tests", \testNegative());
+        addTestCase("corner case tests", \testCornerCases());
+        addTestCase("provider info test", \testProviderInfo());
+        set_return_value(main());
+    }
+
+    globalSetUp() {
+        Logger logger("test", LoggerLevel::getLevelInfo());
+        if (m_options.verbose > 2) {
+            logger.addAppender(new StdoutAppender());
+        }
+        hash<HttpServerOptionInfo> http_opts = <HttpServerOptionInfo>{
+            "logger": logger,
+            "debug": True,
+        };
+
+        mcpServer = new TestMcpServerHandler(logger);
+        server = new HttpServer(http_opts);
+        server.setHandler("mcp", "", MimeTypeJson, mcpServer);
+        server.setDefaultHandler("mcp", mcpServer);
+        port = server.addListener(<HttpListenerOptionInfo>{"service": 0}).port;
+
+        # Create MCP client and initialize
+        string url = sprintf("http://localhost:%d/mcp", port);
+        client = new McpClient(url);
+        client.initialize(<McpClientInfo>{"name": "TestClient", "version": "1.0"});
+
+        # Create data provider
+        provider = new McpClientDataProvider(client);
+    }
+
+    globalTearDown() {
+        delete provider;
+        if (client) {
+            client.close();
+        }
+        if (server) {
+            server.stop();
+            delete server;
+        }
+    }
+
+    testFactory() {
+        # Test factory creation
+        McpClientDataProviderFactory factory();
+        assertEq("McpClientDataProvider", factory.getInfo().name);
+
+        # Test factory getClass
+        Class cls = factory.getClass();
+        assertEq("McpClientDataProvider", cls.getName());
+    }
+
+    testChildren() {
+        # Test root provider children
+        list<string> children = provider.getChildProviderNames();
+        assertTrue(children.contains("tools"));
+        assertTrue(children.contains("resources"));
+        assertTrue(children.contains("prompts"));
+        assertTrue(children.contains("completion"));
+        assertTrue(children.contains("ping"));
+
+        # Test getting child providers
+        assertTrue(exists provider.getChildProvider("tools"));
+        assertTrue(exists provider.getChildProvider("resources"));
+        assertTrue(exists provider.getChildProvider("prompts"));
+        assertTrue(exists provider.getChildProvider("completion"));
+        assertTrue(exists provider.getChildProvider("ping"));
+
+        # Test tools children
+        AbstractDataProvider tools = provider.getChildProvider("tools");
+        list<string> toolsChildren = tools.getChildProviderNames();
+        assertTrue(toolsChildren.contains("list"));
+        assertTrue(toolsChildren.contains("call"));
+
+        # Test resources children
+        AbstractDataProvider resources = provider.getChildProvider("resources");
+        list<string> resourcesChildren = resources.getChildProviderNames();
+        assertTrue(resourcesChildren.contains("list"));
+        assertTrue(resourcesChildren.contains("read"));
+
+        # Test prompts children
+        AbstractDataProvider prompts = provider.getChildProvider("prompts");
+        list<string> promptsChildren = prompts.getChildProviderNames();
+        assertTrue(promptsChildren.contains("list"));
+        assertTrue(promptsChildren.contains("get"));
+    }
+
+    testToolsProvider() {
+        # Test list tools
+        AbstractDataProvider listProvider = provider.getChildProvider("tools").getChildProvider("list");
+        hash<auto> listResult = listProvider.doRequest({});
+        assertEq(Type::List, listResult.tools.type());
+        assertEq(4, listResult.tools.size());
+
+        # Find the echo tool
+        *hash<auto> echoTool = (map $1, listResult.tools, $1.name == "echo")[0];
+        assertTrue(exists echoTool);
+        assertEq("echo", echoTool.name);
+        assertEq("Echoes the input", echoTool.description);
+
+        # Test call tool
+        AbstractDataProvider callProvider = provider.getChildProvider("tools").getChildProvider("call");
+        hash<auto> callResult = callProvider.doRequest({
+            "name": "echo",
+            "arguments": {"message": "Hello, DataProvider!"},
+        });
+        assertEq(Type::List, callResult.content.type());
+
+        # Test call tool with add
+        hash<auto> addResult = callProvider.doRequest({
+            "name": "add",
+            "arguments": {"a": 5, "b": 3},
+        });
+        assertEq(Type::List, addResult.content.type());
+    }
+
+    testResourcesProvider() {
+        # Test list resources
+        AbstractDataProvider listProvider = provider.getChildProvider("resources").getChildProvider("list");
+        hash<auto> listResult = listProvider.doRequest({});
+        assertEq(Type::List, listResult.resources.type());
+        assertEq(2, listResult.resources.size());
+        # Find test.txt resource
+        *hash<auto> testResource = (map $1, listResult.resources, $1.uri == "file:///test.txt")[0];
+        assertTrue(exists testResource);
+
+        # Test read resource
+        AbstractDataProvider readProvider = provider.getChildProvider("resources").getChildProvider("read");
+        hash<auto> readResult = readProvider.doRequest({
+            "uri": "file:///test.txt",
+        });
+        assertEq(Type::List, readResult.contents.type());
+        assertEq("Hello, World!", readResult.contents[0].text);
+    }
+
+    testPromptsProvider() {
+        # Test list prompts
+        AbstractDataProvider listProvider = provider.getChildProvider("prompts").getChildProvider("list");
+        hash<auto> listResult = listProvider.doRequest({});
+        assertEq(Type::List, listResult.prompts.type());
+        assertEq(2, listResult.prompts.size());
+        # Find greeting prompt
+        *hash<auto> greetingPrompt = (map $1, listResult.prompts, $1.name == "greeting")[0];
+        assertTrue(exists greetingPrompt);
+
+        # Test get prompt
+        AbstractDataProvider getProvider = provider.getChildProvider("prompts").getChildProvider("get");
+        hash<auto> getResult = getProvider.doRequest({
+            "name": "greeting",
+            "arguments": {"name": "World"},
+        });
+        assertEq(Type::List, getResult.messages.type());
+        assertEq("Hello, World", getResult.messages[0].content.text);
+    }
+
+    testPingProvider() {
+        # Test ping
+        AbstractDataProvider pingProvider = provider.getChildProvider("ping");
+        hash<auto> pingResult = pingProvider.doRequest({});
+        assertEq(Type::Hash, pingResult.type());
+    }
+
+    testTypeDefinitions() {
+        # Test that type definitions exist and have correct structure
+        assertTrue(exists McpContentItemDataType);
+        assertTrue(exists McpToolResultDataType);
+        assertTrue(exists McpToolInfoDataType);
+        assertTrue(exists McpResourceInfoDataType);
+        assertTrue(exists McpPromptInfoDataType);
+        assertTrue(exists McpToolCallRequestDataType);
+        assertTrue(exists McpResourceReadRequestDataType);
+        assertTrue(exists McpPromptGetRequestDataType);
+        assertTrue(exists McpCompletionRequestDataType);
+        assertTrue(exists McpCompletionResultDataType);
+
+        # Test that types have expected fields
+        hash<auto> contentFields = McpContentItemDataType.getFields();
+        assertTrue(contentFields.hasKey("type"));
+        assertTrue(contentFields.hasKey("text"));
+        assertTrue(contentFields.hasKey("mimeType"));
+
+        hash<auto> toolInfoFields = McpToolInfoDataType.getFields();
+        assertTrue(toolInfoFields.hasKey("name"));
+        assertTrue(toolInfoFields.hasKey("description"));
+        assertTrue(toolInfoFields.hasKey("inputSchema"));
+    }
+
+    testCompletionProvider() {
+        # Test completion provider
+        AbstractDataProvider completionProvider = provider.getChildProvider("completion");
+        assertTrue(exists completionProvider);
+        assertEq("completion", completionProvider.getName());
+
+        # Test completion for prompt argument
+        hash<auto> result = completionProvider.doRequest({
+            "ref_type": "ref/prompt",
+            "ref_name": "greeting",
+            "argument_name": "name",
+            "argument_value": "A",
+        });
+        assertTrue(exists result.values);
+        assertEq(Type::List, result.values.type());
+    }
+
+    testNegative() {
+        # Test calling unknown tool - throws exception with error info
+        AbstractDataProvider callProvider = provider.getChildProvider("tools").getChildProvider("call");
+        bool gotException = False;
+        try {
+            callProvider.doRequest({
+                "name": "nonexistent-tool",
+                "arguments": {},
+            });
+        } catch (hash<ExceptionInfo> ex) {
+            gotException = True;
+            assertEq("MCP-ERROR", ex.err);
+            assertTrue(ex.arg.content[0].isError);
+        }
+        assertTrue(gotException, "Calling unknown tool should throw exception");
+
+        # Test calling tool that throws error
+        gotException = False;
+        try {
+            callProvider.doRequest({
+                "name": "error-tool",
+                "arguments": {},
+            });
+        } catch (hash<ExceptionInfo> ex) {
+            gotException = True;
+            assertEq("MCP-ERROR", ex.err);
+            assertTrue(ex.arg.content[0].isError);
+        }
+        assertTrue(gotException, "Calling error tool should throw exception");
+
+        # Test reading unknown resource - should throw exception
+        AbstractDataProvider readProvider = provider.getChildProvider("resources").getChildProvider("read");
+        gotException = False;
+        try {
+            readProvider.doRequest({"uri": "file:///nonexistent.txt"});
+        } catch (hash<ExceptionInfo> ex) {
+            gotException = True;
+        }
+        assertTrue(gotException, "Reading unknown resource should throw exception");
+
+        # Test getting unknown prompt - should throw exception
+        AbstractDataProvider getProvider = provider.getChildProvider("prompts").getChildProvider("get");
+        gotException = False;
+        try {
+            getProvider.doRequest({"name": "nonexistent-prompt"});
+        } catch (hash<ExceptionInfo> ex) {
+            gotException = True;
+        }
+        assertTrue(gotException, "Getting unknown prompt should throw exception");
+
+        # Test getting unknown child provider
+        *AbstractDataProvider unknownChild = provider.getChildProvider("unknown");
+        assertNothing(unknownChild, "Unknown child provider should return NOTHING");
+
+        # Test tools provider unknown child
+        AbstractDataProvider toolsProvider = provider.getChildProvider("tools");
+        unknownChild = toolsProvider.getChildProvider("unknown");
+        assertNothing(unknownChild, "Unknown tools child should return NOTHING");
+    }
+
+    testCornerCases() {
+        # Test tool with no arguments
+        AbstractDataProvider callProvider = provider.getChildProvider("tools").getChildProvider("call");
+        hash<auto> result = callProvider.doRequest({
+            "name": "no-args-tool",
+        });
+        assertEq(Type::List, result.content.type());
+        assertFalse(result.content[0].isError);
+
+        # Test tool with empty arguments
+        result = callProvider.doRequest({
+            "name": "no-args-tool",
+            "arguments": {},
+        });
+        assertFalse(result.content[0].isError);
+
+        # Test reading empty file resource
+        AbstractDataProvider readProvider = provider.getChildProvider("resources").getChildProvider("read");
+        hash<auto> readResult = readProvider.doRequest({
+            "uri": "file:///empty.txt",
+        });
+        assertEq(Type::List, readResult.contents.type());
+        assertEq("", readResult.contents[0].text);
+
+        # Test prompt with no arguments (simple prompt)
+        AbstractDataProvider getProvider = provider.getChildProvider("prompts").getChildProvider("get");
+        hash<auto> getResult = getProvider.doRequest({
+            "name": "simple",
+        });
+        assertEq(Type::List, getResult.messages.type());
+
+        # Test prompt with empty arguments hash
+        getResult = getProvider.doRequest({
+            "name": "greeting",
+            "arguments": {},
+        });
+        assertEq(Type::List, getResult.messages.type());
+        # Should use default "World" when name not provided
+        assertTrue(getResult.messages[0].content.text.find("World") >= 0);
+
+        # Test list operations return empty lists when no items (would need separate test server)
+        # This tests that list operations work with non-empty lists
+        AbstractDataProvider listProvider = provider.getChildProvider("tools").getChildProvider("list");
+        hash<auto> listResult = listProvider.doRequest({});
+        assertTrue(listResult.tools.size() > 0);
+
+        listProvider = provider.getChildProvider("resources").getChildProvider("list");
+        listResult = listProvider.doRequest({});
+        assertTrue(listResult.resources.size() > 0);
+
+        listProvider = provider.getChildProvider("prompts").getChildProvider("list");
+        listResult = listProvider.doRequest({});
+        assertTrue(listResult.prompts.size() > 0);
+    }
+
+    testProviderInfo() {
+        # Test root provider info
+        hash<auto> info = provider.getInfo();
+        assertEq("mcp", info.name);
+        assertTrue(info.supports_children);
+
+        # Test factory info
+        McpClientDataProviderFactory factory();
+        hash<auto> factoryInfo = factory.getInfo();
+        assertEq("McpClientDataProvider", factoryInfo.name);
+        assertTrue(factoryInfo.children_can_support_apis);
+
+        # Test tools provider info
+        AbstractDataProvider toolsProvider = provider.getChildProvider("tools");
+        info = toolsProvider.getInfo();
+        assertEq("tools", info.name);
+        assertTrue(info.supports_children);
+
+        # Test tools/list provider info
+        AbstractDataProvider listProvider = toolsProvider.getChildProvider("list");
+        info = listProvider.getInfo();
+        assertEq("list", info.name);
+        assertTrue(info.supports_request);
+
+        # Test tools/call provider info
+        AbstractDataProvider callProvider = toolsProvider.getChildProvider("call");
+        info = callProvider.getInfo();
+        assertEq("call", info.name);
+        assertTrue(info.supports_request);
+
+        # Test ping provider info
+        AbstractDataProvider pingProvider = provider.getChildProvider("ping");
+        info = pingProvider.getInfo();
+        assertEq("ping", info.name);
+        assertTrue(info.supports_request);
+
+        # Test completion provider info
+        AbstractDataProvider completionProvider = provider.getChildProvider("completion");
+        info = completionProvider.getInfo();
+        assertEq("completion", info.name);
+        assertTrue(info.supports_request);
+    }
+}


### PR DESCRIPTION
## Summary

Add a new `McpClientDataProvider` module that provides a DataProvider API for MCP (Model Context Protocol) servers, enabling integration with AI tools, resources, and prompts through Qore's standard data provider infrastructure.

- **Factory registration** for automatic data provider discovery
- **Tools provider**: list and call MCP tools
- **Resources provider**: list and read MCP resources
- **Prompts provider**: list and get MCP prompts
- **Completion provider**: get autocompletion suggestions
- **Ping provider**: verify server connectivity
- **ConnectionProvider integration** for connection management
- **Comprehensive type definitions** for all MCP data structures
- Uses `@assert()` for runtime validation and `@debug()` for logging

## Test Plan

- [x] Run `test/McpClientDataProvider.qtest` - 11 test cases, 91 assertions
  - Factory and children tests
  - Tools, resources, prompts, ping, completion providers
  - Type definitions validation
  - Negative tests (error handling for unknown tools, resources, prompts)
  - Corner case tests (empty arguments, default values)
  - Provider info and metadata tests
- [x] Run all existing tests to ensure no regressions
  - `test/json.qtest` - 11 test cases, 106 assertions ✓
  - `test/McpClient.qtest` - 18 test cases, 102 assertions ✓
  - `test/McpServerHandler.qtest` - 14 test cases, 158 assertions ✓

**Related Issue:** https://github.com/qoretechnologies/qore/issues/5061

🤖 Generated with [Claude Code](https://claude.com/claude-code)