### PR TITLE
Add JWT support and type-safe JSON schema

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(CPP_SRC
 set(QMOD
     qlib/JsonRpcHandler.qm
     qlib/JsonRpcConnection.qm
+    qlib/Jwt.qm
     qlib/McpServerHandler
     qlib/McpClient
     qlib/McpClientDataProvider
@@ -87,6 +88,7 @@ qore_user_modules("${QMOD}")
 
 qore_external_user_module("qlib/JsonRpcConnection.qm" "")
 qore_external_user_module("qlib/JsonRpcHandler.qm" "")
+qore_external_user_module("qlib/Jwt.qm" "")
 qore_external_user_module("qlib/McpServerHandler" "JsonRpcHandler")
 qore_external_user_module("qlib/McpClient" "")
 qore_external_user_module("qlib/McpClientDataProvider" "McpClient")

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ noinst_HEADERS = src/QC_JsonRpcClient.h \
     src/ql_json.h \
     src/qore-json-module.h
 
-USER_MODULES = qlib/JsonRpcHandler.qm qlib/JsonRpcConnection.qm qlib/McpServerHandler qlib/McpClient qlib/McpClientDataProvider qlib/NdjsonDataProvider
+USER_MODULES = qlib/JsonRpcHandler.qm qlib/JsonRpcConnection.qm qlib/Jwt.qm qlib/McpServerHandler qlib/McpClient qlib/McpClientDataProvider qlib/NdjsonDataProvider
 
 EXTRA_DIST = COPYING.LGPL COPYING.MIT AUTHORS README \
     RELEASE-NOTES \
@@ -22,6 +22,7 @@ EXTRA_DIST = COPYING.LGPL COPYING.MIT AUTHORS README \
     test/json.qtest \
     test/JsonSax.qtest \
     test/JsonSchema.qtest \
+    test/Jwt.qtest \
     test/Ndjson.qtest \
     examples/json-rpc-client.q \
     examples/JsonRpcServerValidation.q \
@@ -34,11 +35,11 @@ ACLOCAL_AMFLAGS=-I m4
 dist_mod_DATA = $(USER_MODULES)
 
 if COND_DOXYGEN
-DOX = json JsonRpcHandler JsonRpcConnection McpServerHandler
-DOXYGEN_OUTPUT=docs/json/html docs/JsonRpcHandler/html docs/JsonRpcConnection/html docs/McpServerHandler/html
+DOX = json JsonRpcHandler JsonRpcConnection Jwt McpServerHandler
+DOXYGEN_OUTPUT=docs/json/html docs/JsonRpcHandler/html docs/JsonRpcConnection/html docs/Jwt/html docs/McpServerHandler/html
 DOXYFILES = docs/doxyfile docs/mainpage.doxygen
 DOXYFILES_SRC = docs/doxyfile.tmpl docs/qlib/Doxyfile.tmpl docs/footer_template.html
-QLIB_TMP_DOXYFILES = docs/qlib/JsonRpcHandler.qm.dox.h docs/qlib/Doxyfile.JsonRpcHandler docs/qlib/JsonRpcConnection.qm.dox.h docs/qlib/Doxyfile.JsonRpcConnection docs/qlib/McpServerHandler.qm.dox.h docs/qlib/McpServerHandler.qc.dox.h docs/qlib/McpServerConnection.qc.dox.h docs/qlib/Doxyfile.McpServerHandler
+QLIB_TMP_DOXYFILES = docs/qlib/JsonRpcHandler.qm.dox.h docs/qlib/Doxyfile.JsonRpcHandler docs/qlib/JsonRpcConnection.qm.dox.h docs/qlib/Doxyfile.JsonRpcConnection docs/qlib/Jwt.qm.dox.h docs/qlib/Doxyfile.Jwt docs/qlib/McpServerHandler.qm.dox.h docs/qlib/McpServerHandler.qc.dox.h docs/qlib/McpServerConnection.qc.dox.h docs/qlib/Doxyfile.McpServerHandler
 QDX = qdx
 DX_CLEANFILES = ${DOXYFILES} $(QLIB_TMP_DOXYFILES)
 
@@ -60,11 +61,21 @@ docs/qlib/Doxyfile.JsonRpcConnection: docs/qlib/Doxyfile.tmp
     $(QDX) -M=qlib/JsonRpcConnection.qm:qlib/JsonRpcConnection.qm.dox.h -tjson.tag=../../json/html $< $@
 
 docs/qlib/JsonRpcConnection.qm.dox.h: qlib/JsonRpcConnection.qm
-    $(QDX) $< $@
+	$(QDX) $< $@
 
 docs/JsonRpcConnection/html: docs/qlib/JsonRpcConnection.qm.dox.h docs/qlib/Doxyfile.JsonRpcConnection
-    cd docs; $(DOXYGEN_CMD) qlib/Doxyfile.JsonRpcConnection
-    $(QDX) --post docs/JsonRpcConnection/html docs/JsonRpcConnection/html/search
+	cd docs; $(DOXYGEN_CMD) qlib/Doxyfile.JsonRpcConnection
+	$(QDX) --post docs/JsonRpcConnection/html docs/JsonRpcConnection/html/search
+
+docs/qlib/Doxyfile.Jwt: docs/qlib/Doxyfile.tmp
+	$(QDX) -M=qlib/Jwt.qm:qlib/Jwt.qm.dox.h -tjson.tag=../../json/html $< $@
+
+docs/qlib/Jwt.qm.dox.h: qlib/Jwt.qm
+	$(QDX) $< $@
+
+docs/Jwt/html: docs/qlib/Jwt.qm.dox.h docs/qlib/Doxyfile.Jwt
+	cd docs; $(DOXYGEN_CMD) qlib/Doxyfile.Jwt
+	$(QDX) --post docs/Jwt/html docs/Jwt/html/search
 
 docs/qlib/Doxyfile.McpServerHandler: docs/qlib/Doxyfile.tmp
     $(QDX) -M=qlib/McpServerHandler.qm:qlib/McpServerHandler.qm.dox.h -tjson.tag=../../json/html $< $@

--- a/docs/mainpage.doxygen.tmpl
+++ b/docs/mainpage.doxygen.tmpl
@@ -17,6 +17,8 @@
       - @ref Qore::Json::json_pointer_get() "json_pointer_get()"
       - @ref Qore::Json::json_pointer_exists() "json_pointer_exists()"
       - @ref Qore::Json::json_pointer_escape() "json_pointer_escape()"
+      - @ref Qore::Json::jwt_encode() "jwt_encode()"
+      - @ref Qore::Json::jwt_decode() "jwt_decode()"
       - @ref Qore::Json::make_jsonrpc_error() "make_jsonrpc_error()"
       - @ref Qore::Json::make_jsonrpc_request() "make_jsonrpc_request()"
       - @ref Qore::Json::make_jsonrpc_response() "make_jsonrpc_response()"
@@ -172,6 +174,12 @@
     flag is resolved at parse time, a \c "deprecated" warning is raised (assuming this warning is enabled).
 
     @section jsonreleasenotes Release Notes
+
+    @subsection json_v1_11 json Module Version 1.11
+    - added JWT encode/decode support with HS* and RS* algorithms
+    - added JWT hashdecl examples for typed inputs/outputs in the API docs
+    - jwt_decode() now documents BASE64-PARSE-ERROR and JSON-ERROR for invalid tokens
+    - JsonSchema validation result and error lists now use typed hashdecls for type safety
 
     @subsection json_v1_10_1 json Module Version 1.10.1
     - added enums and allowed values metadata for MCP data provider request/response fields

--- a/qlib/Jwt.qm
+++ b/qlib/Jwt.qm
@@ -1,0 +1,73 @@
+# -*- mode: qore; indent-tabs-mode: nil -*-
+#! @file Jwt.qm @brief JWT helpers for the json module
+
+/*  Jwt.qm Copyright (C) 2026 Qore Technologies, s.r.o.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+%requires qore >= 2.0
+%requires json >= 1.11
+
+%modern
+%strict-args
+%require-types
+
+module Jwt {
+    version = "1.0";
+    desc = "JWT helpers for the json module";
+    author = "David Nichols <david@qore.org>";
+    url = "http://qore.org";
+    license = "MIT";
+}
+
+/** @mainpage Jwt Module
+
+    @tableofcontents
+
+    @section jwt_intro Introduction
+
+    This module provides typed helpers around the json module's JWT functions.
+
+    @section jwt_example Example
+    @code{.py}
+%requires Jwt
+
+hash<JwtClaims> claims = cast<hash<JwtClaims>>({
+    "sub": "123",
+    "exp": 1710000000,
+    "extra": {"role": "admin"},
+});
+
+string token = Jwt::encode(claims, "secret");
+hash<JwtDecodeResult> result = Jwt::decode(token, "secret");
+@endcode
+*/
+
+public namespace Jwt {
+    //! Encodes a JWT token
+    public string encode(hash<JwtClaims> claims, string key, string alg = "HS256", *hash<JwtHeader> header = NULL) {
+        return Qore::Json::jwt_encode(claims, key, alg, header);
+    }
+
+    //! Decodes a JWT token
+    public hash<JwtDecodeResult> decode(string token, *string key = NULL, bool verify_signature = True) {
+        return cast<hash<JwtDecodeResult>>(Qore::Json::jwt_decode(token, key, verify_signature));
+    }
+}

--- a/qore-json-module.spec
+++ b/qore-json-module.spec
@@ -100,6 +100,7 @@ qore -l ./json-api-%{module_api}.qmod test/McpServerHandler.qtest -v
 qore -l ./json-api-%{module_api}.qmod test/McpClient.qtest -v
 qore -l ./json-api-%{module_api}.qmod test/McpClientDataProvider.qtest -v
 qore -l ./json-api-%{module_api}.qmod test/json.qtest -v
+qore -l ./json-api-%{module_api}.qmod test/Jwt.qtest -v
 
 %package doc
 Summary: JSON module for Qore

--- a/src/JsonSchemaImpl.cpp
+++ b/src/JsonSchemaImpl.cpp
@@ -23,6 +23,10 @@
 #include "QC_JsonSchema.h"
 
 #include <sstream>
+#include <cassert>
+
+const TypedHashDecl* hashdeclJsonSchemaValidationError = nullptr;
+const TypedHashDecl* hashdeclJsonSchemaValidationResult = nullptr;
 
 JsonSchemaValidator::JsonSchemaValidator(const QoreStringNode* schema_json, ExceptionSink* xsink)
     : valid(false) {
@@ -237,7 +241,10 @@ bool JsonSchemaValidator::validate(QoreValue data, ExceptionSink* xsink) const {
 }
 
 QoreHashNode* JsonSchemaValidator::validateWithErrors(QoreValue data, ExceptionSink* xsink) const {
-    ReferenceHolder<QoreHashNode> result(new QoreHashNode(autoTypeInfo), xsink);
+    assert(hashdeclJsonSchemaValidationError);
+    assert(hashdeclJsonSchemaValidationResult);
+
+    ReferenceHolder<QoreHashNode> result(new QoreHashNode(hashdeclJsonSchemaValidationResult, xsink), xsink);
 
     if (!valid || !schema) {
         xsink->raiseException("JSON-SCHEMA-ERROR", "Schema is not valid");
@@ -251,9 +258,11 @@ QoreHashNode* JsonSchemaValidator::validateWithErrors(QoreValue data, ExceptionS
         }
 
         // Create an error handler that collects all errors
-        ReferenceHolder<QoreListNode> error_list(new QoreListNode(autoTypeInfo), xsink);
+        ReferenceHolder<QoreListNode> error_list(
+            new QoreListNode(hashdeclJsonSchemaValidationError->getTypeInfo()), xsink
+        );
         auto reporter = [&error_list, xsink](const jsoncons::jsonschema::validation_message& msg) {
-            ReferenceHolder<QoreHashNode> err(new QoreHashNode(autoTypeInfo), xsink);
+            ReferenceHolder<QoreHashNode> err(new QoreHashNode(hashdeclJsonSchemaValidationError, xsink), xsink);
             err->setKeyValue("path", new QoreStringNode(msg.instance_location().string()), xsink);
             err->setKeyValue("schema_path", new QoreStringNode(msg.schema_location().string()), xsink);
             err->setKeyValue("keyword", new QoreStringNode(msg.keyword()), xsink);

--- a/src/QC_JsonSchema.h
+++ b/src/QC_JsonSchema.h
@@ -33,6 +33,10 @@
 #include <vector>
 
 DLLLOCAL QoreClass* initJsonSchemaClass(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_JsonSchemaValidationError(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_JsonSchemaValidationResult(QoreNamespace& ns);
+DLLLOCAL extern const TypedHashDecl* hashdeclJsonSchemaValidationError;
+DLLLOCAL extern const TypedHashDecl* hashdeclJsonSchemaValidationResult;
 
 //! JSON Schema validation error structure
 struct JsonSchemaError {

--- a/src/QC_JsonSchema.qpp
+++ b/src/QC_JsonSchema.qpp
@@ -22,6 +22,7 @@
 
 #include "qore-json-module.h"
 #include "QC_JsonSchema.h"
+#include "ql_json.h"
 
 /** @defgroup json_schema_constants JSON Schema Constants
     JSON Schema related constants
@@ -58,15 +59,73 @@ hashdecl JsonSchemaValidationResult {
     //! Whether validation succeeded
     bool valid;
     //! List of validation errors (empty if valid)
-    list<hash<auto>> errors;
+    list<hash<JsonSchemaValidationError>> errors;
+}
+
+//! JWT header parameters
+/** @since json 1.11
+*/
+hashdecl JwtHeader {
+    //! Algorithm (ex: HS256, RS256)
+    string alg;
+    //! Type (ex: "JWT")
+    *string typ;
+    //! Key ID
+    *string kid;
+    //! Content type
+    *string cty;
+    //! Critical header parameters
+    *list<string> crit;
+    //! Custom header parameters
+    *hash<auto> extra;
+}
+
+//! JWT claims
+/** @since json 1.11
+*/
+hashdecl JwtClaims {
+    //! Issuer
+    *string iss;
+    //! Subject
+    *string sub;
+    //! Audience (string)
+    *string aud;
+    //! Expiration time (UNIX epoch seconds)
+    *int exp;
+    //! Not before time (UNIX epoch seconds)
+    *int nbf;
+    //! Issued at time (UNIX epoch seconds)
+    *int iat;
+    //! JWT ID
+    *string jti;
+    //! Custom claims
+    *hash<auto> extra;
+}
+
+//! JWT decode result
+/** @since json 1.11
+*/
+hashdecl JwtDecodeResult {
+    //! Decoded header
+    hash<JwtHeader> header;
+    //! Decoded claims
+    hash<JwtClaims> claims;
+    //! Algorithm used
+    string alg;
+    //! Base64url header + payload used for signing
+    string signing_input;
+    //! Raw signature
+    binary signature;
+    //! Signature validation result
+    bool signature_valid;
 }
 
 //! The JsonSchema class provides JSON Schema validation functionality
 /** This class allows validating JSON/Qore data against a JSON Schema definition.
     It supports JSON Schema draft-07, draft-2019-09, and draft-2020-12.
 
-    @par Example:
-    @code{.py}
+@par Example:
+@code{.py}
 %new-style
 %strict-args
 %require-types
@@ -94,9 +153,9 @@ if (!result.valid) {
         printf("Error at %s: %s\n", err.path, err.message);
     }
 }
-    @endcode
+@endcode
 
-    @since json 1.11
+@since json 1.11
 */
 qclass JsonSchema [arg=JsonSchemaValidator* jschema; ns=Qore::Json];
 
@@ -198,18 +257,18 @@ bool JsonSchema::validate(auto data, bool throw_on_error = False) {
 
     @return a hash with 'valid' (bool) and 'errors' (list of JsonSchemaValidationError hashes)
 
-    @par Example:
-    @code{.py}
+@par Example:
+@code{.py}
 JsonSchema validator(schema);
-hash<auto> result = validator.validateWithErrors(data);
+hash<JsonSchemaValidationResult> result = validator.validateWithErrors(data);
 if (!result.valid) {
-    foreach hash<auto> err in (result.errors) {
+    foreach hash<JsonSchemaValidationError> err in (result.errors) {
         printf("Error at %s: %s\n", err.path, err.message);
     }
 }
-    @endcode
+@endcode
 */
-hash<auto> JsonSchema::validateWithErrors(auto data) {
+hash<JsonSchemaValidationResult> JsonSchema::validateWithErrors(auto data) {
     return jschema->validateWithErrors(data, xsink);
 }
 

--- a/src/json-module.cpp
+++ b/src/json-module.cpp
@@ -53,6 +53,11 @@ DLLEXPORT char qore_module_license_str[] = "MIT";
 QoreNamespace JNS("Qore::Json");
 
 QoreStringNode *json_module_init() {
+   hashdeclJwtHeader = init_hashdecl_JwtHeader(JNS);
+   hashdeclJwtClaims = init_hashdecl_JwtClaims(JNS);
+   hashdeclJwtDecodeResult = init_hashdecl_JwtDecodeResult(JNS);
+   hashdeclJsonSchemaValidationError = init_hashdecl_JsonSchemaValidationError(JNS);
+   hashdeclJsonSchemaValidationResult = init_hashdecl_JsonSchemaValidationResult(JNS);
    JNS.addSystemClass(initJsonRpcClientClass(JNS));
    JNS.addSystemClass(initJsonSaxParserClass(JNS));
    JNS.addSystemClass(initJsonSchemaClass(JNS));

--- a/src/ql_json.h
+++ b/src/ql_json.h
@@ -37,5 +37,11 @@ DLLEXPORT QoreValue parse_json(const QoreString* str, ExceptionSink* xsink);
 
 DLLLOCAL void init_json_functions(QoreNamespace& ns);
 DLLLOCAL void init_json_constants(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_JwtHeader(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_JwtClaims(QoreNamespace& ns);
+DLLLOCAL TypedHashDecl* init_hashdecl_JwtDecodeResult(QoreNamespace& ns);
+DLLLOCAL extern const TypedHashDecl* hashdeclJwtHeader;
+DLLLOCAL extern const TypedHashDecl* hashdeclJwtClaims;
+DLLLOCAL extern const TypedHashDecl* hashdeclJwtDecodeResult;
 
 #endif // _QORE_QL_JSON_H

--- a/src/ql_json.qpp
+++ b/src/ql_json.qpp
@@ -31,6 +31,12 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <cmath>
+#include <cassert>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/pem.h>
 
 // RFC 4627 JSON specification
 // qore only supports JSON with UTF-8
@@ -48,6 +54,356 @@ static int cmp_rest_token(const char*& p, const char* tok) {
         return 0;
     }
     return -1;
+}
+
+const TypedHashDecl* hashdeclJwtHeader = nullptr;
+const TypedHashDecl* hashdeclJwtClaims = nullptr;
+const TypedHashDecl* hashdeclJwtDecodeResult = nullptr;
+
+static const EVP_MD* jwt_get_md(const char* alg, bool& is_hmac, bool& is_rsa, ExceptionSink* xsink) {
+    is_hmac = false;
+    is_rsa = false;
+    if (!strcmp(alg, "HS256")) {
+        is_hmac = true;
+        return EVP_sha256();
+    }
+    if (!strcmp(alg, "HS384")) {
+        is_hmac = true;
+        return EVP_sha384();
+    }
+    if (!strcmp(alg, "HS512")) {
+        is_hmac = true;
+        return EVP_sha512();
+    }
+    if (!strcmp(alg, "RS256")) {
+        is_rsa = true;
+        return EVP_sha256();
+    }
+    if (!strcmp(alg, "RS384")) {
+        is_rsa = true;
+        return EVP_sha384();
+    }
+    if (!strcmp(alg, "RS512")) {
+        is_rsa = true;
+        return EVP_sha512();
+    }
+
+    xsink->raiseException("JWT-ERROR", "unsupported JWT algorithm: %s", alg);
+    return nullptr;
+}
+
+static BinaryNode* jwt_sign_hmac(const EVP_MD* md, const QoreString& key, const QoreString& input,
+        ExceptionSink* xsink) {
+    unsigned int len = 0;
+    unsigned char buf[EVP_MAX_MD_SIZE];
+    if (!HMAC(md, key.getBuffer(), key.size(), reinterpret_cast<const unsigned char*>(input.getBuffer()),
+        input.size(), buf, &len)) {
+        xsink->raiseException("JWT-ERROR", "HMAC signing failed");
+        return nullptr;
+    }
+    ReferenceHolder<BinaryNode> bin(new BinaryNode(), xsink);
+    bin->append(buf, len);
+    return bin.release();
+}
+
+static BinaryNode* jwt_sign_rsa(const EVP_MD* md, const QoreString& key, const QoreString& input,
+        ExceptionSink* xsink) {
+    BIO* bio = BIO_new_mem_buf(key.getBuffer(), key.size());
+    if (!bio) {
+        xsink->raiseException("JWT-ERROR", "failed to allocate key buffer");
+        return nullptr;
+    }
+    EVP_PKEY* pkey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
+    BIO_free(bio);
+    if (!pkey) {
+        xsink->raiseException("JWT-ERROR", "failed to read RSA private key");
+        return nullptr;
+    }
+
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    if (!ctx) {
+        EVP_PKEY_free(pkey);
+        xsink->raiseException("JWT-ERROR", "failed to allocate digest context");
+        return nullptr;
+    }
+
+    if (EVP_DigestSignInit(ctx, nullptr, md, nullptr, pkey) != 1) {
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        xsink->raiseException("JWT-ERROR", "RSA signing init failed");
+        return nullptr;
+    }
+    if (EVP_DigestSignUpdate(ctx, input.getBuffer(), input.size()) != 1) {
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        xsink->raiseException("JWT-ERROR", "RSA signing update failed");
+        return nullptr;
+    }
+    size_t siglen = 0;
+    if (EVP_DigestSignFinal(ctx, nullptr, &siglen) != 1) {
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        xsink->raiseException("JWT-ERROR", "RSA signing final length failed");
+        return nullptr;
+    }
+    std::unique_ptr<unsigned char[]> sig(new unsigned char[siglen]);
+    if (EVP_DigestSignFinal(ctx, sig.get(), &siglen) != 1) {
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        xsink->raiseException("JWT-ERROR", "RSA signing failed");
+        return nullptr;
+    }
+
+    EVP_MD_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+
+    ReferenceHolder<BinaryNode> bin(new BinaryNode(), xsink);
+    bin->append(sig.get(), siglen);
+    return bin.release();
+}
+
+static bool jwt_verify_hmac(const EVP_MD* md, const QoreString& key, const QoreString& input,
+        const BinaryNode* signature, ExceptionSink* xsink) {
+    ReferenceHolder<BinaryNode> expected(jwt_sign_hmac(md, key, input, xsink), xsink);
+    if (*xsink) {
+        return false;
+    }
+    if (expected->size() != signature->size()) {
+        return false;
+    }
+    return CRYPTO_memcmp(expected->getPtr(), signature->getPtr(), signature->size()) == 0;
+}
+
+static bool jwt_verify_rsa(const EVP_MD* md, const QoreString& key, const QoreString& input,
+        const BinaryNode* signature, ExceptionSink* xsink) {
+    BIO* bio = BIO_new_mem_buf(key.getBuffer(), key.size());
+    if (!bio) {
+        xsink->raiseException("JWT-ERROR", "failed to allocate key buffer");
+        return false;
+    }
+    EVP_PKEY* pkey = PEM_read_bio_PUBKEY(bio, nullptr, nullptr, nullptr);
+    BIO_free(bio);
+    if (!pkey) {
+        bio = BIO_new_mem_buf(key.getBuffer(), key.size());
+        if (!bio) {
+            xsink->raiseException("JWT-ERROR", "failed to allocate key buffer");
+            return false;
+        }
+        pkey = PEM_read_bio_PrivateKey(bio, nullptr, nullptr, nullptr);
+        BIO_free(bio);
+    }
+    if (!pkey) {
+        xsink->raiseException("JWT-ERROR", "failed to read RSA public/private key");
+        return false;
+    }
+
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    if (!ctx) {
+        EVP_PKEY_free(pkey);
+        xsink->raiseException("JWT-ERROR", "failed to allocate digest context");
+        return false;
+    }
+    if (EVP_DigestVerifyInit(ctx, nullptr, md, nullptr, pkey) != 1) {
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        xsink->raiseException("JWT-ERROR", "RSA verify init failed");
+        return false;
+    }
+    if (EVP_DigestVerifyUpdate(ctx, input.getBuffer(), input.size()) != 1) {
+        EVP_MD_CTX_free(ctx);
+        EVP_PKEY_free(pkey);
+        xsink->raiseException("JWT-ERROR", "RSA verify update failed");
+        return false;
+    }
+    int rc = EVP_DigestVerifyFinal(ctx,
+        reinterpret_cast<const unsigned char*>(signature->getPtr()), signature->size());
+    EVP_MD_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    if (rc < 0) {
+        xsink->raiseException("JWT-ERROR", "RSA verify failed");
+        return false;
+    }
+    return rc == 1;
+}
+
+static QoreStringNode* jwt_b64url_encode_string(const QoreString& str) {
+    QoreStringNode* out = new QoreStringNode(QCS_UTF8);
+    out->concatBase64Url(str);
+    return out;
+}
+
+static QoreStringNode* jwt_b64url_decode_string(const QoreString& str, ExceptionSink* xsink) {
+    QoreStringNodeHolder tmp(new QoreStringNode(str.getBuffer(), str.size(), QCS_UTF8));
+    return tmp->parseBase64UrlToString(QCS_UTF8, xsink);
+}
+
+static BinaryNode* jwt_b64url_decode_binary(const QoreString& str, ExceptionSink* xsink) {
+    QoreString tmp(str.getBuffer(), str.size(), QCS_UTF8);
+    return tmp.parseBase64Url(xsink);
+}
+
+static QoreHashNode* jwt_build_payload_from_claims(const QoreHashNode* claims, ExceptionSink* xsink) {
+    ReferenceHolder<QoreHashNode> payload(new QoreHashNode(autoTypeInfo), xsink);
+    if (!claims) {
+        xsink->raiseException("JWT-ERROR", "claims cannot be null");
+        return nullptr;
+    }
+    QoreValue v;
+    if (!(v = claims->getKeyValue("iss")).isNullOrNothing()) {
+        payload->setKeyValue("iss", v.refSelf(), xsink);
+    }
+    if (!(v = claims->getKeyValue("sub")).isNullOrNothing()) {
+        payload->setKeyValue("sub", v.refSelf(), xsink);
+    }
+    if (!(v = claims->getKeyValue("aud")).isNullOrNothing()) {
+        payload->setKeyValue("aud", v.refSelf(), xsink);
+    }
+    if (!(v = claims->getKeyValue("exp")).isNullOrNothing()) {
+        payload->setKeyValue("exp", v.refSelf(), xsink);
+    }
+    if (!(v = claims->getKeyValue("nbf")).isNullOrNothing()) {
+        payload->setKeyValue("nbf", v.refSelf(), xsink);
+    }
+    if (!(v = claims->getKeyValue("iat")).isNullOrNothing()) {
+        payload->setKeyValue("iat", v.refSelf(), xsink);
+    }
+    if (!(v = claims->getKeyValue("jti")).isNullOrNothing()) {
+        payload->setKeyValue("jti", v.refSelf(), xsink);
+    }
+
+    QoreHashNode* extra = claims->getKeyValue("extra").get<QoreHashNode>();
+    if (extra) {
+        ConstHashIterator it(extra);
+        while (it.next()) {
+            if (payload->existsKey(it.getKey())) {
+                xsink->raiseException("JWT-ERROR", "duplicate claim key: %s", it.getKey());
+                return nullptr;
+            }
+            payload->setKeyValue(it.getKey(), it.get().refSelf(), xsink);
+            if (*xsink) {
+                return nullptr;
+            }
+        }
+    }
+    return payload.release();
+}
+
+static QoreHashNode* jwt_build_header_from_input(const QoreHashNode* header, const QoreString& alg,
+        ExceptionSink* xsink) {
+    ReferenceHolder<QoreHashNode> out(new QoreHashNode(autoTypeInfo), xsink);
+    out->setKeyValue("alg", new QoreStringNode(alg.c_str()), xsink);
+    out->setKeyValue("typ", new QoreStringNode("JWT"), xsink);
+
+    if (header) {
+        QoreValue v;
+        if (!(v = header->getKeyValue("typ")).isNullOrNothing()) {
+            out->setKeyValue("typ", v.refSelf(), xsink);
+        }
+        if (!(v = header->getKeyValue("kid")).isNullOrNothing()) {
+            out->setKeyValue("kid", v.refSelf(), xsink);
+        }
+        if (!(v = header->getKeyValue("cty")).isNullOrNothing()) {
+            out->setKeyValue("cty", v.refSelf(), xsink);
+        }
+        if (!(v = header->getKeyValue("crit")).isNullOrNothing()) {
+            out->setKeyValue("crit", v.refSelf(), xsink);
+        }
+        QoreHashNode* extra = header->getKeyValue("extra").get<QoreHashNode>();
+        if (extra) {
+            ConstHashIterator it(extra);
+            while (it.next()) {
+                if (out->existsKey(it.getKey())) {
+                    xsink->raiseException("JWT-ERROR", "duplicate header key: %s", it.getKey());
+                    return nullptr;
+                }
+                out->setKeyValue(it.getKey(), it.get().refSelf(), xsink);
+                if (*xsink) {
+                    return nullptr;
+                }
+            }
+        }
+    }
+    return out.release();
+}
+
+static QoreHashNode* jwt_extract_header(const QoreHashNode* header, ExceptionSink* xsink) {
+    assert(hashdeclJwtHeader);
+    if (!header) {
+        xsink->raiseException("JWT-ERROR", "JWT header must be a hash");
+        return nullptr;
+    }
+    ReferenceHolder<QoreHashNode> out(new QoreHashNode(hashdeclJwtHeader, xsink), xsink);
+    ReferenceHolder<QoreHashNode> extra(new QoreHashNode(autoTypeInfo), xsink);
+
+    ConstHashIterator it(header);
+    while (it.next()) {
+        const char* key = it.getKey();
+        QoreValue v = it.get();
+        if (!strcmp(key, "alg")) {
+            if (v.getType() != NT_STRING) {
+                xsink->raiseException("JWT-ERROR", "JWT header 'alg' must be a string");
+                return nullptr;
+            }
+            out->setKeyValue("alg", v.refSelf(), xsink);
+        } else if (!strcmp(key, "typ")) {
+            out->setKeyValue("typ", v.refSelf(), xsink);
+        } else if (!strcmp(key, "kid")) {
+            out->setKeyValue("kid", v.refSelf(), xsink);
+        } else if (!strcmp(key, "cty")) {
+            out->setKeyValue("cty", v.refSelf(), xsink);
+        } else if (!strcmp(key, "crit")) {
+            out->setKeyValue("crit", v.refSelf(), xsink);
+        } else {
+            extra->setKeyValue(key, v.refSelf(), xsink);
+        }
+        if (*xsink) {
+            return nullptr;
+        }
+    }
+    if (extra->size()) {
+        out->setKeyValue("extra", extra.release(), xsink);
+    }
+    return out.release();
+}
+
+static QoreHashNode* jwt_extract_claims(const QoreHashNode* payload, ExceptionSink* xsink) {
+    assert(hashdeclJwtClaims);
+    if (!payload) {
+        xsink->raiseException("JWT-ERROR", "JWT payload must be a hash");
+        return nullptr;
+    }
+    ReferenceHolder<QoreHashNode> out(new QoreHashNode(hashdeclJwtClaims, xsink), xsink);
+    ReferenceHolder<QoreHashNode> extra(new QoreHashNode(autoTypeInfo), xsink);
+
+    ConstHashIterator it(payload);
+    while (it.next()) {
+        const char* key = it.getKey();
+        QoreValue v = it.get();
+        if (!strcmp(key, "iss")) {
+            out->setKeyValue("iss", v.refSelf(), xsink);
+        } else if (!strcmp(key, "sub")) {
+            out->setKeyValue("sub", v.refSelf(), xsink);
+        } else if (!strcmp(key, "aud")) {
+            out->setKeyValue("aud", v.refSelf(), xsink);
+        } else if (!strcmp(key, "exp")) {
+            out->setKeyValue("exp", v.refSelf(), xsink);
+        } else if (!strcmp(key, "nbf")) {
+            out->setKeyValue("nbf", v.refSelf(), xsink);
+        } else if (!strcmp(key, "iat")) {
+            out->setKeyValue("iat", v.refSelf(), xsink);
+        } else if (!strcmp(key, "jti")) {
+            out->setKeyValue("jti", v.refSelf(), xsink);
+        } else {
+            extra->setKeyValue(key, v.refSelf(), xsink);
+        }
+        if (*xsink) {
+            return nullptr;
+        }
+    }
+    if (extra->size()) {
+        out->setKeyValue("extra", extra.release(), xsink);
+    }
+    return out.release();
 }
 
 static void skip_whitespace(const char*& buf, int& line_number) {
@@ -1558,5 +1914,250 @@ string json_pointer_escape(string token) [flags=CONSTANT] {
         ++p;
     }
     return str;
+}
+///@}
+
+/** @defgroup jwt_functions JWT Functions
+ */
+///@{
+namespace Qore::Json;
+
+//! Encodes JWT (JWS) tokens using HS* or RS* algorithms
+/** @param claims the JWT claims (use hash<JwtClaims> for type safety)
+    @param key the signing key (HMAC secret or RSA private key in PEM)
+    @param alg optional algorithm (default: "HS256")
+    @param header optional header parameters (use hash<JwtHeader> when provided)
+
+    @return the JWT token string
+
+    @par Example:
+    @code{.py}
+    %new-style
+    %strict-args
+    %require-types
+
+    hash<JwtClaims> claims = cast<hash<JwtClaims>>({
+        "sub": "123",
+        "exp": 1710000000,
+        "extra": {"role": "admin"}
+    });
+    hash<JwtHeader> header = cast<hash<JwtHeader>>({
+        "typ": "JWT",
+        "extra": {"kid": "key-1"}
+    });
+
+    string token = jwt_encode(claims, "secret", "HS256", header);
+    @endcode
+
+    @throw JWT-ERROR if encoding fails or the algorithm is unsupported
+
+    @since json 1.11
+*/
+string jwt_encode(hash<auto> claims, string key, *string alg, *hash<auto> header) [flags=RET_VALUE_ONLY] {
+    assert(hashdeclJwtHeader);
+    assert(hashdeclJwtClaims);
+
+    ReferenceHolder<QoreHashNode> claims_cast(hashdeclJwtClaims->doRuntimeCast(claims, xsink), xsink);
+    if (*xsink) {
+        return 0;
+    }
+    ReferenceHolder<QoreHashNode> header_cast(xsink);
+    if (header) {
+        header_cast = hashdeclJwtHeader->doRuntimeCast(header, xsink);
+        if (*xsink) {
+            return 0;
+        }
+    }
+
+    QoreString alg_str(QCS_UTF8);
+    if (alg) {
+        alg_str.concat(alg->c_str());
+    } else {
+        alg_str.concat("HS256");
+    }
+
+    ReferenceHolder<QoreHashNode> header_hash(jwt_build_header_from_input(header_cast ? *header_cast : nullptr,
+        alg_str, xsink), xsink);
+    if (*xsink) {
+        return 0;
+    }
+    ReferenceHolder<QoreHashNode> payload_hash(jwt_build_payload_from_claims(*claims_cast, xsink), xsink);
+    if (*xsink) {
+        return 0;
+    }
+
+    QoreStringNodeHolder header_json(new QoreStringNode(QCS_UTF8));
+    if (do_json_value(*header_json, *header_hash, -1, xsink)) {
+        return 0;
+    }
+    QoreStringNodeHolder payload_json(new QoreStringNode(QCS_UTF8));
+    if (do_json_value(*payload_json, *payload_hash, -1, xsink)) {
+        return 0;
+    }
+
+    ReferenceHolder<QoreStringNode> header_b64(jwt_b64url_encode_string(*header_json), xsink);
+    ReferenceHolder<QoreStringNode> payload_b64(jwt_b64url_encode_string(*payload_json), xsink);
+
+    QoreString signing_input(QCS_UTF8);
+    signing_input.concat(header_b64->c_str());
+    signing_input.concat('.');
+    signing_input.concat(payload_b64->c_str());
+
+    bool is_hmac = false;
+    bool is_rsa = false;
+    const EVP_MD* md = jwt_get_md(alg_str.c_str(), is_hmac, is_rsa, xsink);
+    if (*xsink) {
+        return 0;
+    }
+
+    QoreString key_str(key->c_str(), QCS_UTF8);
+    ReferenceHolder<BinaryNode> signature(xsink);
+    if (is_hmac) {
+        signature = jwt_sign_hmac(md, key_str, signing_input, xsink);
+    } else if (is_rsa) {
+        signature = jwt_sign_rsa(md, key_str, signing_input, xsink);
+    }
+    if (*xsink || !signature) {
+        return 0;
+    }
+
+    QoreStringNodeHolder sig_b64(new QoreStringNode(QCS_UTF8));
+    BinaryNode* sig_bin = *signature;
+    sig_b64->concatBase64Url(*sig_bin);
+
+    QoreStringNodeHolder token(new QoreStringNode(QCS_UTF8));
+    token->concat(signing_input.c_str());
+    token->concat('.');
+    token->concat(sig_b64->c_str());
+    return token.release();
+}
+
+//! Decodes a JWT token and optionally verifies the signature
+/** @param token the JWT token string
+    @param key optional verification key (HMAC secret or RSA public key in PEM; private key is accepted as fallback)
+    @param verify_signature flag (default: True)
+
+    @return decoded header, claims, and signature verification info (hash<JwtDecodeResult>)
+
+    @par Example:
+    @code{.py}
+    hash<JwtDecodeResult> result = cast<hash<JwtDecodeResult>>(jwt_decode(token, "secret"));
+    if (!result.signature_valid) {
+        raise "JWT-ERROR", "signature validation failed";
+    }
+    printf("alg=%s sub=%s\n", result.alg, result.claims.sub);
+    @endcode
+
+    @throw JWT-ERROR if decoding fails or verification fails due to missing key/unsupported algorithm
+    @throw BASE64-PARSE-ERROR if any token segment is not valid base64url
+    @throw JSON-ERROR if decoded header or payload is not valid JSON
+
+    @since json 1.11
+*/
+hash<auto> jwt_decode(string token, *string key, bool verify_signature = True) [flags=RET_VALUE_ONLY] {
+    assert(hashdeclJwtDecodeResult);
+    assert(hashdeclJwtHeader);
+    assert(hashdeclJwtClaims);
+
+    std::string t(token->c_str());
+    size_t dot1 = t.find('.');
+    size_t dot2 = t.rfind('.');
+    if (dot1 == std::string::npos || dot2 == std::string::npos || dot1 == dot2) {
+        xsink->raiseException("JWT-ERROR", "invalid JWT format");
+        return QoreValue();
+    }
+
+    QoreString header_b64(t.substr(0, dot1).c_str(), QCS_UTF8);
+    QoreString payload_b64(t.substr(dot1 + 1, dot2 - dot1 - 1).c_str(), QCS_UTF8);
+    QoreString sig_b64(t.substr(dot2 + 1).c_str(), QCS_UTF8);
+
+    ReferenceHolder<QoreStringNode> header_json(jwt_b64url_decode_string(header_b64, xsink), xsink);
+    if (*xsink || !header_json) {
+        return QoreValue();
+    }
+    ReferenceHolder<QoreStringNode> payload_json(jwt_b64url_decode_string(payload_b64, xsink), xsink);
+    if (*xsink || !payload_json) {
+        return QoreValue();
+    }
+
+    ValueHolder header_val(parse_json(*header_json, xsink), xsink);
+    if (*xsink || !header_val) {
+        return QoreValue();
+    }
+    ValueHolder payload_val(parse_json(*payload_json, xsink), xsink);
+    if (*xsink || !payload_val) {
+        return QoreValue();
+    }
+
+    QoreValue header_qv = *header_val;
+    QoreValue payload_qv = *payload_val;
+    if (header_qv.getType() != NT_HASH || payload_qv.getType() != NT_HASH) {
+        xsink->raiseException("JWT-ERROR", "JWT header and payload must be JSON objects");
+        return QoreValue();
+    }
+    QoreHashNode* header_hash = header_qv.get<QoreHashNode>();
+    QoreHashNode* payload_hash = payload_qv.get<QoreHashNode>();
+    if (!header_hash || !payload_hash) {
+        xsink->raiseException("JWT-ERROR", "JWT header and payload must be JSON objects");
+        return QoreValue();
+    }
+
+    ReferenceHolder<QoreHashNode> header(jwt_extract_header(header_hash, xsink), xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+    QoreStringValueHelper alg_value(header->getKeyValue("alg"), QCS_UTF8, xsink);
+    if (*xsink || !alg_value->size()) {
+        xsink->raiseException("JWT-ERROR", "JWT header missing 'alg'");
+        return QoreValue();
+    }
+    QoreString alg_str(alg_value->c_str(), QCS_UTF8);
+
+    ReferenceHolder<QoreHashNode> claims(jwt_extract_claims(payload_hash, xsink), xsink);
+    if (*xsink) {
+        return QoreValue();
+    }
+
+    ReferenceHolder<BinaryNode> signature(jwt_b64url_decode_binary(sig_b64, xsink), xsink);
+    if (*xsink || !signature) {
+        return QoreValue();
+    }
+
+    QoreString signing_input(QCS_UTF8);
+    signing_input.concat(header_b64.c_str());
+    signing_input.concat('.');
+    signing_input.concat(payload_b64.c_str());
+
+    bool signature_valid = false;
+    if (verify_signature) {
+        if (!key) {
+            xsink->raiseException("JWT-ERROR", "JWT verification key is required");
+            return QoreValue();
+        }
+        bool is_hmac = false;
+        bool is_rsa = false;
+        const EVP_MD* md = jwt_get_md(alg_str.c_str(), is_hmac, is_rsa, xsink);
+        if (*xsink) {
+            return QoreValue();
+        }
+        QoreString key_str(key->c_str(), QCS_UTF8);
+        if (is_hmac) {
+            signature_valid = jwt_verify_hmac(md, key_str, signing_input, *signature, xsink);
+        } else if (is_rsa) {
+            signature_valid = jwt_verify_rsa(md, key_str, signing_input, *signature, xsink);
+        }
+        if (*xsink) {
+            return QoreValue();
+        }
+    }
+
+    ReferenceHolder<QoreHashNode> result(new QoreHashNode(hashdeclJwtDecodeResult, xsink), xsink);
+    result->setKeyValue("header", header.release(), xsink);
+    result->setKeyValue("claims", claims.release(), xsink);
+    result->setKeyValue("alg", new QoreStringNode(alg_str.c_str()), xsink);
+    result->setKeyValue("signing_input", new QoreStringNode(signing_input.c_str()), xsink);
+    result->setKeyValue("signature", signature.release(), xsink);
+    result->setKeyValue("signature_valid", signature_valid, xsink);
+    return result.release();
 }
 ///@}

--- a/test/JsonSchema.qtest
+++ b/test/JsonSchema.qtest
@@ -30,6 +30,7 @@ class JsonSchemaTest inherits QUnit::Test {
         addTestCase("Validation errors", \testValidationErrors());
         addTestCase("Invalid schema", \testInvalidSchema());
         addTestCase("Nested objects", \testNestedObjects());
+        addTestCase("Type safety", \testTypeSafety());
         set_return_value(main());
     }
 
@@ -142,10 +143,10 @@ class JsonSchemaTest inherits QUnit::Test {
 
     testValidationErrors() {
         JsonSchema v('{"type": "string"}');
-        hash<auto> result = v.validateWithErrors(42);
+        hash<JsonSchemaValidationResult> result = v.validateWithErrors(42);
         assertFalse(result.valid);
         assertTrue(result.errors.size() > 0);
-        hash<auto> first_error = result.errors[0];
+        hash<JsonSchemaValidationError> first_error = result.errors[0];
         assertTrue(exists first_error.path);
         assertTrue(exists first_error.message);
         assertTrue(exists first_error.keyword);
@@ -161,5 +162,19 @@ class JsonSchemaTest inherits QUnit::Test {
         JsonSchema v('{"type": "object", "properties": {"address": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}');
         assertTrue(v.validate({"address": {"city": "Springfield"}}));
         assertFalse(v.validate({"address": {"street": "123 Main St"}}));
+    }
+
+    testTypeSafety() {
+        JsonSchema v('{"type": "string"}');
+        hash<JsonSchemaValidationResult> result = v.validateWithErrors(42);
+        assertFalse(result.valid);
+        assertThrows("RUNTIME-TYPE-ERROR", sub() {
+            auto bad = "bad";
+            result.errors += bad;
+        });
+        assertThrows("RUNTIME-TYPE-ERROR", sub() {
+            auto bad_list = ("bad");
+            result.errors = bad_list;
+        });
     }
 }

--- a/test/Jwt.qtest
+++ b/test/Jwt.qtest
@@ -1,0 +1,204 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+
+%new-style
+%strict-args
+%enable-all-warnings
+%require-types
+
+%requires qore >= 2.0
+%requires json
+%requires QUnit
+
+%exec-class JwtTest
+
+class JwtTest inherits QUnit::Test {
+    private {
+        string rsa_private_key;
+        string rsa_public_key;
+    }
+
+    constructor() : Test("JwtTest", "1.0", \ARGV) {
+        rsa_private_key = "-----BEGIN PRIVATE KEY-----\n" +
+            "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCghY6vbY9TSJQJ\n" +
+            "ub71l64DQ6qs8am74HOzQQMOtUjPe3uHO4NQugxlnpsawbuAM7gGEIsMSZT7SW7t\n" +
+            "HYfIz9F0d1ui/Imj0GmIjRvNIMQULJnB40uODm/oBhGBajFFGpdSy0yT+mN5+bt6\n" +
+            "8PW47PIPo+X8gAFllFtiROdguZB+rr2gjvbqaHYyjiD2HOVc/p+H1I+7XZ8BLxSu\n" +
+            "XBTDLTOhminR7Gb4svEX9eo2b7LhSv4WRVz6M2LwjhIfsWqt/jiTjwM62cKG91K7\n" +
+            "IpFwQ/ApLM21f+YrJJhHkQEbVsv5TEI2I772DYZbF/nUkElPpFvNvUQNpvivKVvA\n" +
+            "ZVmIauQFAgMBAAECggEAI8dRE+HwKciKEpbfrN73jsu0zaJ5yiIPt9scQtl+Vpy3\n" +
+            "3l8R+FrXq4jMGo0m7T7Z3CQw0fbOqanm+xvzaXuEvJhkCPKP/T7VXvXQxgpxGewN\n" +
+            "A23Vp96o68b6fOV+AOCZ7P7aXTtYk9Xph1AQ/Px3Qawu9XZUmV8VdVRVXDZQMiQH\n" +
+            "Sw0ak7Xfl1EU03x+V4QUZDovtL96Jja22gWkYvOcpoIC8DCjDAm37KLztSiHTeju\n" +
+            "pvfajMsa+oXGOxKakAgDhbQ2eS0hODqVOzy9KheaR8896n2VcP3Ci1wY+9d03BCn\n" +
+            "cXhAvamGBqVpAYfBmequmvJgX8JBKfYiv6M4MjTsmwKBgQDLGQ5UYyLeRwkpcpL2\n" +
+            "u+jryaIodInw2KbyokIeniXtkWTdnVSZsHivi0Kek3jQ3RQKGyJBGAc3tUmWZEOm\n" +
+            "kjd7LLtbZ8s5FC4+wUgT7qFl5qYEITUgr0hURDnhdWfdDk+h64wLN6w5BjPyDc2w\n" +
+            "4qj/nouxEwssgjoaMdve8oQIzwKBgQDKVXGEYSWEV0mxqDItcIYRHLEPPWCnuSTK\n" +
+            "Pd1MqkXaw035YukvWa/TJuGA5NQxO00WGrnuTDlMnWeJw4dBD6XD4ddS8V+ngbPx\n" +
+            "ew8RVbQGE8cMbNw7bWqEeAMcP9USPVrwJtiumfv6AT5ugquDKiB6acNp4T9PN30B\n" +
+            "XaRkS3PS6wKBgCjz+Xa8ssg9bLSF3OqRw4rgEqmzrij5lthwLYL9AsrfuYYSdn+z\n" +
+            "HPLQ0vMk64S6P5M2G3ciwDnUfW0s9JM/Ap78yx7IVCtDTXvr/3u9b6AbnThR9eOM\n" +
+            "VLphM4ap5PKnMxmEZK3SYRDylkDl1acoXUmGD8b5/xPPgqXLjflrz4HzAoGBAKWf\n" +
+            "V3KzStCP2wUP1zMW3sd3IwCEj2/7v7/E8DdnUhMGt/ciHhriYWiIdSLbLU63ahxj\n" +
+            "+Dq2Llkmp7A/W6HIOzqizW1Zo6EsLK3Iu8bGzrwCyHbFTWlf4UdaLcGcBsANdTkL\n" +
+            "s2cJKRe2mPJBCEAv5bIOjSVIelhP5YWOr5hhowfNAoGAUtlgdXG6P2wzLwc0wZHD\n" +
+            "Ulv2eeTEqi/IUI6GCKFt3yQyYwsxxa5veJUQ1RlCzA2fyWq5ppmyRpuQAx+T/5mT\n" +
+            "R/exfFdkrCUX3FKc+0mZktlgWQGm26/r6OM94OTw3S2NavcixI9X2QdWlxKnqZ1G\n" +
+            "mY6BajUXBgMP7AhhxO/gZGw=\n" +
+            "-----END PRIVATE KEY-----\n";
+
+        rsa_public_key = "-----BEGIN PUBLIC KEY-----\n" +
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoIWOr22PU0iUCbm+9Zeu\n" +
+            "A0OqrPGpu+Bzs0EDDrVIz3t7hzuDULoMZZ6bGsG7gDO4BhCLDEmU+0lu7R2HyM/R\n" +
+            "dHdbovyJo9BpiI0bzSDEFCyZweNLjg5v6AYRgWoxRRqXUstMk/pjefm7evD1uOzy\n" +
+            "D6Pl/IABZZRbYkTnYLmQfq69oI726mh2Mo4g9hzlXP6fh9SPu12fAS8UrlwUwy0z\n" +
+            "oZop0exm+LLxF/XqNm+y4Ur+FkVc+jNi8I4SH7Fqrf44k48DOtnChvdSuyKRcEPw\n" +
+            "KSzNtX/mKySYR5EBG1bL+UxCNiO+9g2GWxf51JBJT6Rbzb1EDab4rylbwGVZiGrk\n" +
+            "BQIDAQAB\n" +
+            "-----END PUBLIC KEY-----\n";
+
+        addTestCase("HS256 round trip", \testHs256RoundTrip());
+        addTestCase("HS256 wrong key", \testHs256WrongKey());
+        addTestCase("RS256 round trip", \testRs256RoundTrip());
+        addTestCase("RS256 verify with private key", \testRs256VerifyWithPrivateKey());
+        addTestCase("Invalid format", \testInvalidFormat());
+        addTestCase("No verify without key", \testNoVerifyWithoutKey());
+        addTestCase("Missing alg", \testMissingAlg());
+        addTestCase("Non-object header", \testNonObjectHeader());
+        addTestCase("Non-object payload", \testNonObjectPayload());
+        addTestCase("Invalid base64", \testInvalidBase64());
+        addTestCase("Missing key", \testMissingKey());
+        addTestCase("Unsupported algorithm", \testUnsupportedAlg());
+        set_return_value(main());
+    }
+
+    private hash<JwtClaims> buildClaims() {
+        hash<JwtClaims> claims = cast<hash<JwtClaims>>({
+            "iss": "issuer",
+            "sub": "subject",
+            "aud": "audience",
+            "exp": 1700000000,
+            "extra": {"role": "admin"},
+        });
+        return claims;
+    }
+
+    private hash<JwtHeader> buildHeader() {
+        hash<JwtHeader> header = cast<hash<JwtHeader>>({
+            "kid": "key1",
+            "extra": {"foo": "bar"},
+        });
+        return header;
+    }
+
+    private list<string> splitToken(string token) {
+        list<string> parts = token.split(".");
+        @assert(parts.size() == 3);
+        return parts;
+    }
+
+    testHs256RoundTrip() {
+        hash<JwtClaims> claims = buildClaims();
+        hash<JwtHeader> header = buildHeader();
+        string token = jwt_encode(claims, "secret", "HS256", header);
+        hash<JwtDecodeResult> result = cast<hash<JwtDecodeResult>>(jwt_decode(token, "secret"));
+        assertTrue(result.signature_valid);
+        assertEq("issuer", result.claims.iss);
+        assertEq("admin", result.claims.extra.role);
+        assertEq("key1", result.header.kid);
+        assertEq("bar", result.header.extra.foo);
+    }
+
+    testHs256WrongKey() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, "secret", "HS256");
+        hash<JwtDecodeResult> result = cast<hash<JwtDecodeResult>>(jwt_decode(token, "badsecret"));
+        assertFalse(result.signature_valid);
+    }
+
+    testRs256RoundTrip() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, rsa_private_key, "RS256");
+        hash<JwtDecodeResult> result = cast<hash<JwtDecodeResult>>(jwt_decode(token, rsa_public_key));
+        assertTrue(result.signature_valid);
+        assertEq("subject", result.claims.sub);
+    }
+
+    testRs256VerifyWithPrivateKey() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, rsa_private_key, "RS256");
+        hash<JwtDecodeResult> result = cast<hash<JwtDecodeResult>>(jwt_decode(token, rsa_private_key));
+        assertTrue(result.signature_valid);
+    }
+
+    testInvalidFormat() {
+        assertThrows("JWT-ERROR", sub() {
+            auto ignored = jwt_decode("abc", "secret");
+        });
+    }
+
+    testNoVerifyWithoutKey() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, "secret", "HS256");
+        hash<JwtDecodeResult> result = cast<hash<JwtDecodeResult>>(jwt_decode(token, NULL, False));
+        assertFalse(result.signature_valid);
+        assertEq("subject", result.claims.sub);
+    }
+
+    testMissingAlg() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, "secret", "HS256");
+        list<string> parts = splitToken(token);
+        string bad_token = "e30." + parts[1] + "." + parts[2];
+        assertThrows("JWT-ERROR", sub() {
+            auto ignored = jwt_decode(bad_token, NULL, False);
+        });
+    }
+
+    testNonObjectHeader() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, "secret", "HS256");
+        list<string> parts = splitToken(token);
+        string bad_token = "W10." + parts[1] + "." + parts[2];
+        assertThrows("JWT-ERROR", sub() {
+            auto ignored = jwt_decode(bad_token, NULL, False);
+        });
+    }
+
+    testNonObjectPayload() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, "secret", "HS256");
+        list<string> parts = splitToken(token);
+        string header_b64 = "eyJhbGciOiJIUzI1NiJ9";
+        string bad_token = header_b64 + ".W10." + parts[2];
+        assertThrows("JWT-ERROR", sub() {
+            auto ignored = jwt_decode(bad_token, NULL, False);
+        });
+    }
+
+    testInvalidBase64() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, "secret", "HS256");
+        list<string> parts = splitToken(token);
+        string bad_token = "!!!." + parts[1] + "." + parts[2];
+        assertThrows("BASE64-PARSE-ERROR", sub() {
+            auto ignored = jwt_decode(bad_token, NULL, False);
+        });
+    }
+
+    testMissingKey() {
+        hash<JwtClaims> claims = buildClaims();
+        string token = jwt_encode(claims, "secret", "HS256");
+        assertThrows("JWT-ERROR", sub() {
+            auto ignored = jwt_decode(token);
+        });
+    }
+
+    testUnsupportedAlg() {
+        hash<JwtClaims> claims = buildClaims();
+        assertThrows("JWT-ERROR", sub() {
+            auto ignored = jwt_encode(claims, "secret", "ES256");
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add JWT encode/decode APIs and Qore user module
- add JWT tests and docs updates
- replace hash with hashdecls for JsonSchema validation

## Testing
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/json.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/JsonRpcClient.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/JsonRpcHandler.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/JsonSax.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/JsonSchema.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/Jwt.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/McpClientDataProvider.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/McpClient.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/McpServerHandler.qtest -v
- /usr/bin/qore --enable-debug -l ./build/json-api-1.5.qmod test/Ndjson.qtest -v