### PR TITLE
fix(json): combine UTF-16 surrogate pairs in parse_json and the SAX parser

### DIFF
--- a/src/QC_JsonSaxParser.qpp
+++ b/src/QC_JsonSaxParser.qpp
@@ -301,22 +301,60 @@ QoreStringNode* JsonSaxParser::parseString(ParseState& state) {
                     str->concat('\t');
                     break;
                 case 'u': {
-                    char unicode[5];
-                    for (int i = 0; i < 4; ++i) {
-                        int hx = get(state);
+                    // read a single \uXXXX unit (4 hex digits); on error sets xsink and returns (unsigned)-1
+                    auto read_hex4 = [&]() -> unsigned {
+                        char unicode[5];
+                        for (int i = 0; i < 4; ++i) {
+                            int hx = get(state);
+                            if (*state.xsink) {
+                                return (unsigned)-1;
+                            }
+                            if (hx == -1 || !isxdigit((unsigned char)hx)) {
+                                state.xsink->raiseException("JSON-SAX-PARSE-ERROR",
+                                    "invalid unicode escape at line %d, column %d",
+                                    state.line_number, state.column);
+                                return (unsigned)-1;
+                            }
+                            unicode[i] = (char)hx;
+                        }
+                        unicode[4] = '\0';
+                        return (unsigned)strtoul(unicode, 0, 16);
+                    };
+                    unsigned code = read_hex4();
+                    if (*state.xsink) {
+                        return nullptr;
+                    }
+                    // combine a UTF-16 surrogate pair: astral-plane characters (> U+FFFF) are encoded as a
+                    // high surrogate \uD800-DBFF followed by a low surrogate \uDC00-DFFF
+                    if (code >= 0xD800 && code <= 0xDBFF) {
+                        int c1 = get(state);
+                        int c2 = (*state.xsink) ? 0 : get(state);
                         if (*state.xsink) {
                             return nullptr;
                         }
-                        if (hx == -1 || !isxdigit((unsigned char)hx)) {
+                        if (c1 != '\\' || c2 != 'u') {
                             state.xsink->raiseException("JSON-SAX-PARSE-ERROR",
-                                "invalid unicode escape at line %d, column %d",
-                                state.line_number, state.column);
+                                "invalid JSON string: unpaired high surrogate \\u%04X at line %d, column %d",
+                                code, state.line_number, state.column);
                             return nullptr;
                         }
-                        unicode[i] = (char)hx;
+                        unsigned low = read_hex4();
+                        if (*state.xsink) {
+                            return nullptr;
+                        }
+                        if (low < 0xDC00 || low > 0xDFFF) {
+                            state.xsink->raiseException("JSON-SAX-PARSE-ERROR",
+                                "invalid JSON string: high surrogate \\u%04X followed by \\u%04X, which is not "
+                                "a low surrogate, at line %d, column %d", code, low, state.line_number, state.column);
+                            return nullptr;
+                        }
+                        code = 0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00);
+                    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+                        state.xsink->raiseException("JSON-SAX-PARSE-ERROR",
+                            "invalid JSON string: unpaired low surrogate \\u%04X at line %d, column %d",
+                            code, state.line_number, state.column);
+                        return nullptr;
                     }
-                    unicode[4] = '\0';
-                    unsigned code = strtoul(unicode, 0, 16);
                     if (str->concatUnicode(code, state.xsink)) {
                         return nullptr;
                     }

--- a/src/ql_json.qpp
+++ b/src/ql_json.qpp
@@ -456,7 +456,8 @@ static int get_json_string_token(QoreString& str, const char*& buf, int& line_nu
             } else if (*buf == 'u') { // expect a unicode character specification (possibly a surrogate pair)
                 ++buf;
                 // check for 4 hex digits
-                if (isxdigit(*buf) && isxdigit(*(buf + 1)) && isxdigit(*(buf + 2)) && isxdigit(*(buf + 3))) {
+                if (isxdigit((unsigned char)*buf) && isxdigit((unsigned char)*(buf + 1))
+                    && isxdigit((unsigned char)*(buf + 2)) && isxdigit((unsigned char)*(buf + 3))) {
                     char unicode[5];
                     strncpy(unicode, buf, 4);
                     unicode[4] = '\0';
@@ -470,8 +471,8 @@ static int get_json_string_token(QoreString& str, const char*& buf, int& line_nu
                         // characters, so at most the NUL terminator is read, never past it (same idiom
                         // as the 4-hex-digit check above for the first \u unit)
                         if (*(buf + 1) == '\\' && *(buf + 2) == 'u'
-                            && isxdigit(*(buf + 3)) && isxdigit(*(buf + 4))
-                            && isxdigit(*(buf + 5)) && isxdigit(*(buf + 6))) {
+                            && isxdigit((unsigned char)*(buf + 3)) && isxdigit((unsigned char)*(buf + 4))
+                            && isxdigit((unsigned char)*(buf + 5)) && isxdigit((unsigned char)*(buf + 6))) {
                             char low_unicode[5];
                             strncpy(low_unicode, buf + 3, 4);
                             low_unicode[4] = '\0';
@@ -702,7 +703,7 @@ static QoreValue get_json_value(const char*& buf, int& line_number, const QoreEn
     }
 
     // FIXME: implement parsing of JSON exponents
-    if (isdigit(*buf) || (*buf) == '.' || (*buf) == '-') {
+    if (isdigit((unsigned char)*buf) || (*buf) == '.' || (*buf) == '-') {
         // temporarily use a QoreString
         QoreString str;
         bool has_dot;
@@ -750,7 +751,7 @@ static QoreValue get_json_value(const char*& buf, int& line_number, const QoreEn
                     ++buf;
                 }
                 continue;
-            } else if (!isdigit(*buf)) {
+            } else if (!isdigit((unsigned char)*buf)) {
                 xsink->raiseException("JSON-PARSE-ERROR", "unexpected character '%c' in number", *buf);
                 return QoreValue();
             }

--- a/src/ql_json.qpp
+++ b/src/ql_json.qpp
@@ -465,6 +465,10 @@ static int get_json_string_token(QoreString& str, const char*& buf, int& line_nu
                     // combine a UTF-16 surrogate pair: astral-plane characters (> U+FFFF) are encoded in
                     // JSON as a high surrogate \uD800-DBFF followed by a low surrogate \uDC00-DFFF
                     if (code >= 0xD800 && code <= 0xDBFF) {
+                        // the fixed-offset reads below are bounded by && short-circuit evaluation:
+                        // *(buf + N) is only dereferenced when buf+1..buf+(N-1) all matched non-NUL
+                        // characters, so at most the NUL terminator is read, never past it (same idiom
+                        // as the 4-hex-digit check above for the first \u unit)
                         if (*(buf + 1) == '\\' && *(buf + 2) == 'u'
                             && isxdigit(*(buf + 3)) && isxdigit(*(buf + 4))
                             && isxdigit(*(buf + 5)) && isxdigit(*(buf + 6))) {

--- a/src/ql_json.qpp
+++ b/src/ql_json.qpp
@@ -453,7 +453,7 @@ static int get_json_string_token(QoreString& str, const char*& buf, int& line_nu
                 str.concat('\t');
             } else if (*buf == 'v') {
                 str.concat('\v');
-            } else if (*buf == 'u') { // expect a unicode character specification
+            } else if (*buf == 'u') { // expect a unicode character specification (possibly a surrogate pair)
                 ++buf;
                 // check for 4 hex digits
                 if (isxdigit(*buf) && isxdigit(*(buf + 1)) && isxdigit(*(buf + 2)) && isxdigit(*(buf + 3))) {
@@ -461,10 +461,38 @@ static int get_json_string_token(QoreString& str, const char*& buf, int& line_nu
                     strncpy(unicode, buf, 4);
                     unicode[4] = '\0';
                     unsigned code = strtoul(unicode, 0, 16);
+                    buf += 3;
+                    // combine a UTF-16 surrogate pair: astral-plane characters (> U+FFFF) are encoded in
+                    // JSON as a high surrogate \uD800-DBFF followed by a low surrogate \uDC00-DFFF
+                    if (code >= 0xD800 && code <= 0xDBFF) {
+                        if (*(buf + 1) == '\\' && *(buf + 2) == 'u'
+                            && isxdigit(*(buf + 3)) && isxdigit(*(buf + 4))
+                            && isxdigit(*(buf + 5)) && isxdigit(*(buf + 6))) {
+                            char low_unicode[5];
+                            strncpy(low_unicode, buf + 3, 4);
+                            low_unicode[4] = '\0';
+                            unsigned low = strtoul(low_unicode, 0, 16);
+                            if (low < 0xDC00 || low > 0xDFFF) {
+                                xsink->raiseException("JSON-PARSE-ERROR", "invalid JSON string: high surrogate "
+                                    "\\u%04X followed by \\u%04X, which is not a low surrogate, at line %d",
+                                    code, low, line_number);
+                                return -1;
+                            }
+                            code = 0x10000 + ((code - 0xD800) << 10) + (low - 0xDC00);
+                            buf += 6;
+                        } else {
+                            xsink->raiseException("JSON-PARSE-ERROR", "invalid JSON string: unpaired high "
+                                "surrogate \\u%04X at line %d", code, line_number);
+                            return -1;
+                        }
+                    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+                        xsink->raiseException("JSON-PARSE-ERROR", "invalid JSON string: unpaired low surrogate "
+                            "\\u%04X at line %d", code, line_number);
+                        return -1;
+                    }
                     if (str.concatUnicode(code, xsink)) {
                         break;
                     }
-                    buf += 3;
                 } else {
                     str.concat("\\u");
                 }

--- a/test/JsonSurrogatePairs.qtest
+++ b/test/JsonSurrogatePairs.qtest
@@ -1,0 +1,79 @@
+#!/usr/bin/env qore
+# -*- mode: qore; indent-tabs-mode: nil -*-
+# Copyright 2026 Qore Technologies, s.r.o.
+
+%modern
+
+%requires qore >= 2.0
+%requires json
+%requires QUnit
+
+%exec-class JsonSurrogatePairsTest
+
+# Regression coverage for JSON \u surrogate-pair decoding.
+#
+# Astral-plane characters (code points > U+FFFF) are encoded in JSON as a UTF-16
+# surrogate pair: a high surrogate (\uD800-\uDBFF) immediately followed by a low
+# surrogate (\uDC00-\uDFFF). parse_json() (and the streaming SAX parser) must combine
+# the pair into the single scalar code point rather than emitting two lone surrogates
+# as invalid UTF-8. Before the fix, e.g. "🧪" (U+1F9EA) decoded to 6 bytes
+# of lone-surrogate garbage instead of the correct 4-byte UTF-8 sequence.
+class JsonSurrogatePairsTest inherits QUnit::Test {
+    private {
+        # U+1F9EA TEST TUBE 🧪 as a surrogate-pair escape (what json.dumps / JSON.stringify emit)
+        const EmojiSurrogate = "{\"m\": \"a \\ud83e\\uddea b\"}";
+        # the same message with the literal UTF-8 character
+        const EmojiLiteral   = "{\"m\": \"a 🧪 b\"}";
+    }
+
+    constructor() : Test("JsonSurrogatePairsTest", "1.0", \ARGV) {
+        addTestCase("surrogate pair decodes to one code point", \testSurrogatePair());
+        addTestCase("surrogate form equals literal UTF-8", \testEqualsLiteral());
+        addTestCase("unpaired high surrogate is rejected", \testUnpairedHigh());
+        addTestCase("unpaired low surrogate is rejected", \testUnpairedLow());
+        addTestCase("high surrogate + non-low escape is rejected", \testHighThenNonLow());
+        addTestCase("BMP and ASCII escapes unaffected", \testBmpUnaffected());
+        set_return_value(main());
+    }
+
+    private string errOf(code c) {
+        try {
+            c();
+        } catch (hash<ExceptionInfo> ex) {
+            return ex.err;
+        }
+        return "<no-exception>";
+    }
+
+    testSurrogatePair() {
+        hash<auto> h = parse_json(EmojiSurrogate);
+        # "a " (2) + U+1F9EA (4 bytes UTF-8) + " b" (2) = 8 bytes, 5 characters
+        assertEq(8, h.m.size());
+        assertEq(5, h.m.length());
+        assertEq(parse_json(EmojiLiteral).m, h.m);
+    }
+
+    testEqualsLiteral() {
+        assertEq(parse_json(EmojiLiteral), parse_json(EmojiSurrogate));
+    }
+
+    testUnpairedHigh() {
+        assertEq("JSON-PARSE-ERROR", errOf(sub () { parse_json("{\"m\": \"\\ud83e\"}"); }));
+        assertEq("JSON-PARSE-ERROR", errOf(sub () { parse_json("{\"m\": \"\\ud83e X\"}"); }));
+    }
+
+    testUnpairedLow() {
+        assertEq("JSON-PARSE-ERROR", errOf(sub () { parse_json("{\"m\": \"\\uddea\"}"); }));
+    }
+
+    testHighThenNonLow() {
+        # a high surrogate followed by a valid-but-non-low-surrogate \u escape (U+0041 'A')
+        assertEq("JSON-PARSE-ERROR", errOf(sub () { parse_json("{\"m\": \"\\ud83e\\u0041\"}"); }));
+    }
+
+    testBmpUnaffected() {
+        # BMP escapes (<= U+FFFF): em-dash U+2014, e-acute U+00E9, copyright U+00A9
+        assertEq("a — é ©", parse_json("{\"m\": \"a \\u2014 \\u00e9 \\u00a9\"}").m);
+        assertEq("plain ascii", parse_json("{\"m\": \"plain ascii\"}").m);
+    }
+}

--- a/test/JsonSurrogatePairs.qtest
+++ b/test/JsonSurrogatePairs.qtest
@@ -10,14 +10,33 @@
 
 %exec-class JsonSurrogatePairsTest
 
-# Regression coverage for JSON \u surrogate-pair decoding.
+# Input stream returning data one byte at a time, to force the SAX parser to handle a
+# surrogate-pair escape split across read() chunk boundaries.
+class ByteAtATimeInputStream inherits InputStream {
+    private {
+        binary data;
+        int pos = 0;
+    }
+    constructor(string s) { data = binary(s); }
+    int peek() { return pos >= data.size() ? -1 : data[pos]; }
+    *binary read(int limit) {
+        if (limit <= 0 || pos >= data.size()) {
+            return NOTHING;
+        }
+        binary b = data.substr(pos, 1);
+        ++pos;
+        return b;
+    }
+}
+
+# Regression coverage for JSON \u surrogate-pair decoding, for both the DOM parser (parse_json)
+# and the streaming SAX parser (JsonSaxParser).
 #
-# Astral-plane characters (code points > U+FFFF) are encoded in JSON as a UTF-16
-# surrogate pair: a high surrogate (\uD800-\uDBFF) immediately followed by a low
-# surrogate (\uDC00-\uDFFF). parse_json() (and the streaming SAX parser) must combine
-# the pair into the single scalar code point rather than emitting two lone surrogates
-# as invalid UTF-8. Before the fix, e.g. "🧪" (U+1F9EA) decoded to 6 bytes
-# of lone-surrogate garbage instead of the correct 4-byte UTF-8 sequence.
+# Astral-plane characters (code points > U+FFFF) are encoded in JSON as a UTF-16 surrogate pair:
+# a high surrogate (\uD800-\uDBFF) immediately followed by a low surrogate (\uDC00-\uDFFF). The
+# decoder must combine the pair into the single scalar code point rather than emitting two lone
+# surrogates as invalid UTF-8. Before the fix, "🧪" (U+1F9EA) decoded to 6 bytes of
+# lone-surrogate garbage instead of the correct 4-byte UTF-8 sequence.
 class JsonSurrogatePairsTest inherits QUnit::Test {
     private {
         # U+1F9EA TEST TUBE 🧪 as a surrogate-pair escape (what json.dumps / JSON.stringify emit)
@@ -27,12 +46,15 @@ class JsonSurrogatePairsTest inherits QUnit::Test {
     }
 
     constructor() : Test("JsonSurrogatePairsTest", "1.0", \ARGV) {
-        addTestCase("surrogate pair decodes to one code point", \testSurrogatePair());
-        addTestCase("surrogate form equals literal UTF-8", \testEqualsLiteral());
-        addTestCase("unpaired high surrogate is rejected", \testUnpairedHigh());
-        addTestCase("unpaired low surrogate is rejected", \testUnpairedLow());
-        addTestCase("high surrogate + non-low escape is rejected", \testHighThenNonLow());
-        addTestCase("BMP and ASCII escapes unaffected", \testBmpUnaffected());
+        addTestCase("parse_json: surrogate pair decodes to one code point", \testSurrogatePair());
+        addTestCase("parse_json: surrogate form equals literal UTF-8", \testEqualsLiteral());
+        addTestCase("parse_json: unpaired high surrogate is rejected", \testUnpairedHigh());
+        addTestCase("parse_json: unpaired low surrogate is rejected", \testUnpairedLow());
+        addTestCase("parse_json: high surrogate + non-low escape is rejected", \testHighThenNonLow());
+        addTestCase("parse_json: BMP and ASCII escapes unaffected", \testBmpUnaffected());
+        addTestCase("SAX: surrogate pair decodes to one code point", \testSaxSurrogatePair());
+        addTestCase("SAX: surrogate pair split across chunk boundaries", \testSaxSurrogateChunked());
+        addTestCase("SAX: unpaired high surrogate is rejected", \testSaxUnpairedHigh());
         set_return_value(main());
     }
 
@@ -43,6 +65,18 @@ class JsonSurrogatePairsTest inherits QUnit::Test {
             return ex.err;
         }
         return "<no-exception>";
+    }
+
+    # collect the decoded values of all SAX string events emitted while parsing json
+    private list<string> saxStrings(string json) {
+        JsonSaxParser parser();
+        list<string> vals = ();
+        parser.parse(json, sub (hash<auto> e) {
+            if (e.type == JsonSaxString) {
+                push vals, e.value;
+            }
+        });
+        return vals;
     }
 
     testSurrogatePair() {
@@ -75,5 +109,29 @@ class JsonSurrogatePairsTest inherits QUnit::Test {
         # BMP escapes (<= U+FFFF): em-dash U+2014, e-acute U+00E9, copyright U+00A9
         assertEq("a — é ©", parse_json("{\"m\": \"a \\u2014 \\u00e9 \\u00a9\"}").m);
         assertEq("plain ascii", parse_json("{\"m\": \"plain ascii\"}").m);
+    }
+
+    testSaxSurrogatePair() {
+        assertEq(True, inlist("a 🧪 b", saxStrings(EmojiSurrogate)));
+    }
+
+    testSaxSurrogateChunked() {
+        # feed the parser one byte at a time so the \uD83E and \uDDEA units land in separate reads
+        JsonSaxParser parser();
+        list<string> vals = ();
+        ByteAtATimeInputStream stream(EmojiSurrogate);
+        parser.parseStream(stream, sub (hash<auto> e) {
+            if (e.type == JsonSaxString) {
+                push vals, e.value;
+            }
+        });
+        assertEq(True, inlist("a 🧪 b", vals));
+    }
+
+    testSaxUnpairedHigh() {
+        assertEq("JSON-SAX-PARSE-ERROR", errOf(sub () {
+            JsonSaxParser parser();
+            parser.parse("{\"m\": \"\\ud83e\"}", sub (hash<auto> e) {});
+        }));
     }
 }


### PR DESCRIPTION
## Summary

`parse_json()` and the streaming SAX JSON parser never combined UTF-16 **surrogate pairs**, so any astral-plane character (code point > U+FFFF — emoji, some CJK-ext, math symbols) arriving as the standard `\uD800-DBFF\uDC00-DFFF` escape (what `json.dumps(ensure_ascii=True)`, JS `JSON.stringify`, and most REST APIs emit) decoded to **two lone surrogates encoded as invalid UTF-8** instead of the correct code point.

Example: `{"m":"🧪"}` (🧪 U+1F9EA) decoded to a 6-byte lone-surrogate blob instead of the correct 4-byte UTF-8 sequence.

## Root cause

Both parsers read one `\uXXXX` unit and passed it straight to `concatUnicode()` with no surrogate-pair handling:
- `src/ql_json.qpp` — `get_json_string_token()`
- `src/QC_JsonSaxParser.qpp` — the `case 'u'` escape handler

`concatUnicode()` faithfully encodes whatever value it is given (including a lone surrogate), so combining the pair is the caller's responsibility — which was missing.

## Fix

After reading a `\uXXXX` unit, both parsers now:
- if it is a high surrogate (`0xD800`–`0xDBFF`), require the following `\uXXXX` low surrogate (`0xDC00`–`0xDFFF`) and combine: `0x10000 + ((hi - 0xD800) << 10) + (lo - 0xDC00)`;
- raise a clean `JSON-PARSE-ERROR` on an unpaired high surrogate, a lone low surrogate, or a high surrogate followed by a non-low-surrogate escape (RFC 8259 §7).

`make_json` already emits raw UTF-8, so the encoder is unchanged.

## Testing

- New `test/JsonSurrogatePairs.qtest` (6 cases, 10 assertions): surrogate-pair decode, equality with the literal-UTF-8 form, unpaired-high/low rejection, high-then-non-low rejection, BMP/ASCII regression guard.
- Existing JSON tests pass unchanged (JsonFileDataProvider 23/23, Ndjson 15/15, JsonRpcClient 7/7).

## Downstream impact

This corruption fatally crashed Qorus TypeScript app-actions: the `qorus → ts-proxy` command channel serializes commands with `make_yaml`, which emitted the lone surrogates as invalid YAML (`🧪`); the ts-proxy child's `parse_yaml` then rejected it — killing the child mid-command and surfacing to the FSM as `SOCKET-SEND-ERROR: Broken pipe`. Verified end-to-end that an emoji Telegram `send_message` app-action, previously fatal, now delivers with this fix.

Refs qoretechnologies/qorus#397
